### PR TITLE
useLongPress 작성

### DIFF
--- a/src/hooks/common/useLongPress.test.tsx
+++ b/src/hooks/common/useLongPress.test.tsx
@@ -1,0 +1,226 @@
+import { cleanup, fireEvent } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import useLongPress from './useLongPress';
+
+describe('hooks/common/useLongPress', () => {
+  test('정의되어 있는가', () => {
+    expect(useLongPress).toBeDefined();
+  });
+
+  describe('useLongPress in pc', () => {
+    const onLongPressMock = vi.fn();
+    const onPressStartMock = vi.fn();
+    const onPressEndMock = vi.fn();
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      onLongPressMock.mockClear();
+      onPressStartMock.mockClear();
+      onPressEndMock.mockClear();
+    });
+
+    afterEach(cleanup);
+
+    test('threshold 동안 누르고 있으면 onLongPress가 실행된다', () => {
+      const ref = { current: document.createElement('div') };
+      renderHook(() => useLongPress(ref, { onLongPress: onLongPressMock, threshold: 500 }));
+      const element = ref.current;
+
+      fireEvent.mouseDown(element);
+      expect(onLongPressMock).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(499);
+      expect(onLongPressMock).not.toHaveBeenCalled();
+
+      fireEvent.mouseDown(element);
+      vi.advanceTimersByTime(500);
+      expect(onLongPressMock).toHaveBeenCalled();
+    });
+
+    test('누름과 동시에 onPressStart가 실행되고, 떼면 onPressEnd가 실행된다', () => {
+      const ref = { current: document.createElement('div') };
+      renderHook(() =>
+        useLongPress(ref, {
+          onLongPress: onLongPressMock,
+          onPressStart: onPressStartMock,
+          onPressEnd: onPressEndMock,
+          threshold: 500,
+        }),
+      );
+      const element = ref.current;
+
+      fireEvent.mouseDown(element);
+      expect(onPressStartMock).toHaveBeenCalled();
+      fireEvent.mouseUp(element);
+      expect(onPressEndMock).toHaveBeenCalled();
+    });
+
+    test('누르다가 취소될 경우 onPressEnd와 onLongPress가 모두 실행되지 않는다', () => {
+      const ref = { current: document.createElement('div') };
+      renderHook(() =>
+        useLongPress(ref, {
+          onLongPress: onLongPressMock,
+          onPressStart: onPressStartMock,
+          onPressEnd: onPressEndMock,
+          threshold: 500,
+        }),
+      );
+      const element = ref.current;
+
+      fireEvent.mouseDown(element);
+      expect(onPressStartMock).toHaveBeenCalled();
+      fireEvent.mouseLeave(element);
+      vi.advanceTimersByTime(500);
+      expect(onPressEndMock).not.toHaveBeenCalled();
+      expect(onLongPressMock).not.toHaveBeenCalled();
+    });
+
+    test('대상이 null일 경우 이벤트가 등록되지 않는다', () => {
+      const ref = { current: null };
+      renderHook(() =>
+        useLongPress(ref, {
+          onLongPress: onLongPressMock,
+          onPressStart: onPressStartMock,
+          onPressEnd: onPressEndMock,
+          threshold: 500,
+        }),
+      );
+
+      expect(ref.current?.ontouchstart).toBeUndefined();
+      expect(ref.current?.ontouchend).toBeUndefined();
+      expect(ref.current?.ontouchcancel).toBeUndefined();
+      expect(ref.current?.onmousedown).toBeUndefined();
+      expect(ref.current?.onmouseup).toBeUndefined();
+      expect(ref.current?.onmouseleave).toBeUndefined();
+    });
+
+    test('unmount되면 이벤트가 제거된다', () => {
+      const ref = { current: document.createElement('div') };
+      const { unmount } = renderHook(() =>
+        useLongPress(ref, {
+          onLongPress: onLongPressMock,
+          onPressStart: onPressStartMock,
+          onPressEnd: onPressEndMock,
+          threshold: 500,
+        }),
+      );
+      const element = ref.current;
+      const removeEventListener = vi.spyOn(element, 'removeEventListener');
+
+      unmount();
+
+      expect(removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function));
+      expect(removeEventListener).toHaveBeenCalledWith('mouseup', expect.any(Function));
+      expect(removeEventListener).toHaveBeenCalledWith('mouseleave', expect.any(Function));
+    });
+  });
+
+  describe('useLongPress in mobile', () => {
+    const onLongPressMock = vi.fn();
+    const onPressStartMock = vi.fn();
+    const onPressEndMock = vi.fn();
+
+    beforeEach(() => {
+      global.ontouchstart = vi.fn();
+      vi.useFakeTimers();
+      onLongPressMock.mockClear();
+      onPressStartMock.mockClear();
+      onPressEndMock.mockClear();
+    });
+
+    afterEach(cleanup);
+
+    test('threshold 동안 누르고 있으면 onLongPress가 실행된다', () => {
+      const ref = { current: document.createElement('div') };
+      renderHook(() => useLongPress(ref, { onLongPress: onLongPressMock, threshold: 500 }));
+      const element = ref.current;
+
+      fireEvent.touchStart(element);
+      expect(onLongPressMock).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(499);
+      expect(onLongPressMock).not.toHaveBeenCalled();
+
+      fireEvent.touchStart(element);
+      vi.advanceTimersByTime(500);
+      expect(onLongPressMock).toHaveBeenCalled();
+    });
+
+    test('누름과 동시에 onPressStart가 실행되고, 떼면 onPressEnd가 실행된다', () => {
+      const ref = { current: document.createElement('div') };
+      renderHook(() =>
+        useLongPress(ref, {
+          onLongPress: onLongPressMock,
+          onPressStart: onPressStartMock,
+          onPressEnd: onPressEndMock,
+          threshold: 500,
+        }),
+      );
+      const element = ref.current;
+
+      fireEvent.touchStart(element);
+      expect(onPressStartMock).toHaveBeenCalled();
+      fireEvent.touchEnd(element);
+      expect(onPressEndMock).toHaveBeenCalled();
+    });
+
+    test('누르다가 취소될 경우 onPressEnd와 onLongPress가 모두 실행되지 않는다', () => {
+      const ref = { current: document.createElement('div') };
+      renderHook(() =>
+        useLongPress(ref, {
+          onLongPress: onLongPressMock,
+          onPressStart: onPressStartMock,
+          onPressEnd: onPressEndMock,
+          threshold: 500,
+        }),
+      );
+      const element = ref.current;
+
+      fireEvent.touchStart(element);
+      expect(onPressStartMock).toHaveBeenCalled();
+      fireEvent.touchCancel(element);
+      vi.advanceTimersByTime(500);
+      expect(onPressEndMock).not.toHaveBeenCalled();
+      expect(onLongPressMock).not.toHaveBeenCalled();
+    });
+
+    test('대상이 null일 경우 이벤트가 등록되지 않는다', () => {
+      const ref = { current: null };
+      renderHook(() =>
+        useLongPress(ref, {
+          onLongPress: onLongPressMock,
+          onPressStart: onPressStartMock,
+          onPressEnd: onPressEndMock,
+          threshold: 500,
+        }),
+      );
+
+      expect(ref.current?.ontouchstart).toBeUndefined();
+      expect(ref.current?.ontouchend).toBeUndefined();
+      expect(ref.current?.ontouchcancel).toBeUndefined();
+      expect(ref.current?.onmousedown).toBeUndefined();
+      expect(ref.current?.onmouseup).toBeUndefined();
+      expect(ref.current?.onmouseleave).toBeUndefined();
+    });
+
+    test('unmount되면 이벤트가 제거된다', () => {
+      const ref = { current: document.createElement('div') };
+      const { unmount } = renderHook(() =>
+        useLongPress(ref, {
+          onLongPress: onLongPressMock,
+          onPressStart: onPressStartMock,
+          onPressEnd: onPressEndMock,
+          threshold: 500,
+        }),
+      );
+      const element = ref.current;
+      const removeEventListener = vi.spyOn(element, 'removeEventListener');
+
+      unmount();
+
+      expect(removeEventListener).toHaveBeenCalledWith('touchstart', expect.any(Function));
+      expect(removeEventListener).toHaveBeenCalledWith('touchend', expect.any(Function));
+      expect(removeEventListener).toHaveBeenCalledWith('touchcancel', expect.any(Function));
+    });
+  });
+});

--- a/src/hooks/common/useLongPress.ts
+++ b/src/hooks/common/useLongPress.ts
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useRef } from 'react';
 
 type LongPressEvent = MouseEvent | TouchEvent;
 
-type LongPressOptions = {
+interface LongPressOptions {
   onLongPress: (event: LongPressEvent) => void;
   onPressStart?: (event: LongPressEvent) => void;
   onPressEnd?: (event: LongPressEvent) => void;
   threshold?: number;
-};
+}
 
 const useLongPress = (
   ref: React.RefObject<HTMLElement>,

--- a/src/hooks/common/useLongPress.ts
+++ b/src/hooks/common/useLongPress.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+type LongPressEvent = MouseEvent | TouchEvent;
+
+type LongPressOptions = {
+  onLongPress: (event: LongPressEvent) => void;
+  onPressStart?: (event: LongPressEvent) => void;
+  onPressEnd?: (event: LongPressEvent) => void;
+  threshold?: number;
+};
+
+const useLongPress = (
+  ref: React.RefObject<HTMLElement>,
+  { onLongPress, onPressStart, onPressEnd, threshold = 500 }: LongPressOptions,
+) => {
+  const timeoutRef = useRef<number | undefined>();
+  const targetRef = useRef<EventTarget | null>(null);
+
+  const handlePressStart = useCallback(
+    (event: LongPressEvent) => {
+      targetRef.current = event.target;
+      if (onPressStart) onPressStart(event);
+
+      timeoutRef.current = window.setTimeout(() => {
+        if (onLongPress && targetRef.current === event.target) {
+          onLongPress(event);
+        }
+      }, threshold);
+    },
+    [onLongPress, onPressStart, targetRef, threshold],
+  );
+
+  const handlePressEnd = useCallback(
+    (event: LongPressEvent) => {
+      clearTimeout(timeoutRef.current);
+      if (onPressEnd && targetRef.current === event.target) {
+        onPressEnd(event);
+      }
+    },
+    [onPressEnd, targetRef],
+  );
+
+  const handlePressCancel = useCallback(() => {
+    clearTimeout(timeoutRef.current);
+  }, [targetRef]);
+
+  useEffect(() => {
+    const currentRef = ref.current;
+
+    if (!currentRef) {
+      return;
+    }
+
+    if ('ontouchstart' in window) {
+      currentRef.addEventListener('touchstart', handlePressStart);
+      currentRef.addEventListener('touchend', handlePressEnd);
+      currentRef.addEventListener('touchcancel', handlePressCancel);
+    } else {
+      currentRef.addEventListener('mousedown', handlePressStart);
+      currentRef.addEventListener('mouseup', handlePressEnd);
+      currentRef.addEventListener('mouseleave', handlePressCancel);
+    }
+
+    return () => {
+      if ('ontouchstart' in window) {
+        currentRef.removeEventListener('touchstart', handlePressStart);
+        currentRef.removeEventListener('touchend', handlePressEnd);
+        currentRef.removeEventListener('touchcancel', handlePressCancel);
+      } else {
+        currentRef.removeEventListener('mousedown', handlePressStart);
+        currentRef.removeEventListener('mouseup', handlePressEnd);
+        currentRef.removeEventListener('mouseleave', handlePressCancel);
+      }
+    };
+  }, [ref, onPressStart, onLongPress, onPressEnd, threshold, handlePressStart, handlePressEnd, handlePressCancel]);
+};
+
+export default useLongPress;

--- a/src/hooks/common/useLongPress.ts
+++ b/src/hooks/common/useLongPress.ts
@@ -9,6 +9,16 @@ interface LongPressOptions {
   threshold?: number;
 }
 
+/**
+ * 마우스나 터치 이벤트가 threshold 동안 유지될 때 콜백 함수를 실행하는 hook
+ *
+ * @param ref
+ * @param options useLongPress 옵션 객체
+ * @param options.onLongPress threshold 동안 press가 유지될 때 실행할 함수
+ * @param options.onPressStart press가 시작될 때 실행할 함수
+ * @param options.onPressEnd press가 종료될 때 실행할 함수
+ * @param options.threshold 함수 실행 기준 ms, 기본값은 500ms
+ */
 const useLongPress = (
   ref: React.RefObject<HTMLElement>,
   { onLongPress, onPressStart, onPressEnd, threshold = 500 }: LongPressOptions,


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

꾹 눌렀을때 함수를 호출하는 hook 작성

1. `threshold` 동안 누르고 있으면 `onLongPress` 호출
2. 누르는 순간 `onPressStart` 호출
3. 떼는 순간 `onPressEnd` 호출
4. 누르고 바깥으로 이동, 누르고 페이지 이동...? 등 도중에 이벤트가 취소되면 이후 함수 호출 x

![useLongPress](https://user-images.githubusercontent.com/82137004/236645021-d8bdd52a-1010-4d2d-837f-12df364e0472.gif)



## 🎉 변경 사항

### 🙏 여기는 꼭 봐주세요!

### 사용 방법

```js
// ref를 만들고
const buttonRef = useRef<HTMLButtonElement>(null);

// hook에 ref와 options를 넘겨주고
  useLongPress(buttonRef, {
    onLongPress: () => {
      console.log("길게 누름")
    },
    onPressStart: () => {
      console.log("누름")
    },
    onPressEnd: () => {
      console.log("그만 누름")
    },
    threshold: 500,
  });

// ref를 걸어주면 됨
<button ref={buttonRef}>click</button>
```

## 🌄 스크린샷

## 📚 참고
