### PR TITLE
useMouseMove

### DIFF
--- a/src/hooks/mouse/useMouseMove.stories.tsx
+++ b/src/hooks/mouse/useMouseMove.stories.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { css } from '@emotion/react';
+import { type Meta } from '@storybook/react';
+
+import useMouseMove from './useMouseMove';
+
+const meta: Meta = {
+  title: 'useMouseMove',
+};
+
+export default meta;
+
+export function Default() {
+  const [state, setState] = useState({ x: 0, y: 0 });
+  const { ref, isActive } = useMouseMove(setState);
+
+  return (
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      `}
+    >
+      <div
+        ref={ref}
+        css={css`
+          position: relative;
+          width: 300px;
+          height: 200px;
+          background-color: lightblue;
+        `}
+      >
+        <div
+          css={css`
+            position: absolute;
+            top: ${state.y * 100}%;
+            left: ${state.x * 100}%;
+
+            width: 10px;
+            height: 10px;
+
+            background-color: ${isActive ? 'red' : 'blue'};
+          `}
+        ></div>
+      </div>
+
+      <p>isActive : {isActive.toString()}</p>
+      <p>
+        original, x : {state.x}, y : {state.y}
+      </p>
+      <p>
+        visible, x : {Math.round(state.x * 100)}, y : {Math.round(state.y * 100)}
+      </p>
+    </div>
+  );
+}

--- a/src/hooks/mouse/useMouseMove.ts
+++ b/src/hooks/mouse/useMouseMove.ts
@@ -1,0 +1,127 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { clamp } from '~/utils/math';
+
+import useDidMount from '../lifeCycle/useDidMount';
+
+export interface UseMovePosition {
+  x: number;
+  y: number;
+}
+
+interface ScrubHandler {
+  onStart?: () => void;
+  onEnd?: () => void;
+}
+
+const useMouseMove = <T extends HTMLElement = HTMLDivElement>(
+  onChange: (value: UseMovePosition) => void,
+  handler?: ScrubHandler,
+) => {
+  const ref = useRef<T>(null);
+  const mounted = useRef(false);
+  const frame = useRef(0);
+  const isSliding = useRef(false);
+  const [isActive, setIsActive] = useState(false);
+
+  useDidMount(() => {
+    mounted.current = true;
+  });
+
+  useEffect(() => {
+    const onScrub = ({ x, y }: UseMovePosition) => {
+      cancelAnimationFrame(frame.current);
+
+      frame.current = requestAnimationFrame(() => {
+        if (!mounted.current) return;
+        if (!ref.current) return;
+
+        ref.current.style.userSelect = 'none';
+        const rect = ref.current.getBoundingClientRect();
+
+        if (!rect.width) return;
+        if (!rect.height) return;
+
+        const _x = clamp((x - rect.left) / rect.width, 0, 1);
+        const _y = clamp((y - rect.top) / rect.height, 0, 1);
+        onChange({ x: _x, y: _y });
+      });
+    };
+
+    const bindEvents = () => {
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', stopScrub);
+      document.addEventListener('touchmove', onTouchMove);
+      document.addEventListener('touchend', stopScrub);
+    };
+
+    const unbindEvents = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', stopScrub);
+      document.removeEventListener('touchmove', onTouchMove);
+      document.removeEventListener('touchend', stopScrub);
+    };
+
+    const startScrub = () => {
+      if (!mounted.current) return;
+      if (isSliding.current) return;
+
+      isSliding.current = true;
+      setIsActive(true);
+      bindEvents();
+
+      if (typeof handler?.onStart === 'function') handler.onStart();
+    };
+
+    const stopScrub = () => {
+      if (!mounted.current) return;
+      if (!isSliding.current) return;
+
+      isSliding.current = false;
+      setIsActive(false);
+      unbindEvents();
+
+      setTimeout(() => {
+        if (typeof handler?.onEnd === 'function') handler.onEnd();
+      });
+    };
+
+    const onMouseDown = (e: MouseEvent) => {
+      e.preventDefault();
+      startScrub();
+      onMouseMove(e);
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      onScrub({ x: e.clientX, y: e.clientY });
+    };
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.cancelable) e.preventDefault();
+
+      startScrub();
+      onTouchMove(e);
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (e.cancelable) {
+        e.preventDefault();
+      }
+
+      onScrub({ x: e.changedTouches[0].clientX, y: e.changedTouches[0].clientY });
+    };
+
+    ref.current?.addEventListener('mousedown', onMouseDown);
+    ref.current?.addEventListener('touchstart', onTouchStart, { passive: false });
+
+    return () => {
+      if (!ref.current) return;
+      ref.current.removeEventListener('mousedown', onMouseDown);
+      ref.current.removeEventListener('touchstart', onTouchStart);
+    };
+  }, [handler, onChange]);
+
+  return { ref, isActive };
+};
+
+export default useMouseMove;

--- a/src/utils/math.test.ts
+++ b/src/utils/math.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest';
+
+import { clamp } from './math';
+
+describe('utils/math', () => {
+  describe('clamp', () => {
+    test('value보다 max가 작으면 max를 반환한다', () => {
+      expect(clamp(10, 0, 5)).toBe(5);
+    });
+
+    test('value보다 min이 크면 min을 반환한다', () => {
+      expect(clamp(-10, 0, 5)).toBe(0);
+    });
+
+    test('value가 min과 max 사이에 있으면 value를 반환한다', () => {
+      expect(clamp(3, 0, 5)).toBe(3);
+    });
+  });
+});

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,3 @@
+export const clamp = (value: number, min: number, max: number) => {
+  return Math.min(Math.max(value, min), max);
+};


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

close #61 

- 마우스 클릭 혹은 터치 이벤트를 통해 드래그(무브)를 담당할 수 있는 훅을 만들었어요

> 리뷰어의 직업군 선택 시 슬라이드되는 부분에 이용하기 위해 만들었어요

- `clamp` 유틸을 만들었어요


### 🙏 여기는 꼭 봐주세요!

mantine 구현체를 많이 참고했어요

https://mantine.dev/hooks/use-move/
https://github.com/mantinedev/mantine/blob/master/src/mantine-hooks/src/use-move/use-move.ts





### 사용 방법

스토리를 참고해 주세요

https://github.com/depromeet/na-lab-client/blob/b24cb126db286099b03d733f8a318b6a403a8faf/src/hooks/mouse/useMouseMove.stories.tsx#L13-L58

## 🌄 스크린샷

https://github.com/depromeet/na-lab-client/assets/26461307/bc1a944e-7523-44ed-b9c3-339539956324
