### PR TITLE
Portal 컴포넌트 hydration 오류 수정

### DIFF
--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -1,13 +1,21 @@
-import { type PropsWithChildren } from 'react';
+import { type PropsWithChildren, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 /**
  * @description react.createPortal을 이용해 document.body에 children을 렌더링합니다
  */
 const Portal = ({ children }: PropsWithChildren) => {
-  const container = typeof window !== 'undefined' && document.body;
+  const [container, setContainer] = useState<Element | null>(null);
 
-  return container ? createPortal(children, container) : null;
+  useEffect(() => {
+    if (document) {
+      setContainer(document.body);
+    }
+  }, []);
+
+  if (!container) return null;
+
+  return createPortal(children, container);
 };
 
 export default Portal;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

Portal 컴포넌트 사용시, 프리렌더링 결과물과 클라이언트 렌더링 결과물이 상이하여 hydration이 불가한 오류를 수정합니다.
현재 코드는 프리렌더링 결과는 null, 클라이언트 렌더링 결과는 createPortal로 렌더트리가 다르게 생성되어 오류가 발생합니다.
클라이언트에서 null로 렌더된 이후 hydration을 진행, 이후 set으로 createPortal를 렌더합니다.

## 🎉 변경 사항

useEffect, useState를 사용하여 클라이언트에서 렌더링한 결과가 프리렌더링 결과물과 동일하도록 수정하였습니다.

### 🙏 여기는 꼭 봐주세요!

### 사용 방법

## 🌄 스크린샷

## 📚 참고

[공식문서](https://nextjs.org/docs/messages/react-hydration-error)
