### PR TITLE
Color 디자인 시스템 테마에 추가

### DIFF
--- a/src/styles/color.stories.tsx
+++ b/src/styles/color.stories.tsx
@@ -13,7 +13,7 @@ export default meta;
 export function Default() {
   return (
     <ThemeProvider theme={defaultTheme}>
-      <div css={HeadingCss}>Button</div>
+      <div css={headingCss}>Button</div>
       <div css={FlexBoxCss}>
         <div css={[(theme) => ({ backgroundColor: theme.colors.primary_200 }), BoxCss]} />
         <div css={[(theme) => ({ backgroundColor: theme.colors.primary_100 }), BoxCss]} />
@@ -26,7 +26,7 @@ export function Default() {
         <span>$primary.50 (background)</span>
         <span>$primary.300 (button-hover)</span>
       </div>
-      <div css={HeadingCss}>Text & Icon</div>
+      <div css={headingCss}>Text & Icon</div>
       <div css={FlexBoxCss}>
         <div css={[(theme) => ({ backgroundColor: theme.colors.secondary_200 }), BoxCss]} />
         <div css={[(theme) => ({ backgroundColor: theme.colors.secondary_100 }), BoxCss]} />
@@ -37,7 +37,7 @@ export function Default() {
         <span>$secondary.100 (button-disabled)</span>
         <span>$secondary.300 (button-hover)</span>
       </div>
-      <div css={HeadingCss}>Background</div>
+      <div css={headingCss}>Background</div>
       <div css={FlexBoxCss}>
         <div css={[(theme) => ({ backgroundColor: theme.colors.black }), BoxCss]} />
         <div css={[(theme) => ({ backgroundColor: theme.colors.gray_500 }), BoxCss]} />
@@ -62,14 +62,14 @@ export function Default() {
         <span>$gray.100 (background-hover)</span>
         <span>$gray.200 (background-tertiary)</span>
       </div>
-      <div css={HeadingCss}>System Color</div>
+      <div css={headingCss}>System Color</div>
       <div css={FlexBoxCss}>
         <div css={[(theme) => ({ backgroundColor: theme.colors.red }), BoxCss]} />
       </div>
       <div css={FlexBoxCss}>
         <span>$system-red</span>
       </div>
-      <div css={HeadingCss}>Sub Color</div>
+      <div css={headingCss}>Sub Color</div>
       <div css={FlexBoxCss}>
         <div css={[(theme) => ({ backgroundColor: theme.colors.pink }), BoxCss]} />
         <div css={[(theme) => ({ backgroundColor: theme.colors.purple }), BoxCss]} />

--- a/src/styles/color.stories.tsx
+++ b/src/styles/color.stories.tsx
@@ -1,0 +1,116 @@
+import { css, ThemeProvider } from '@emotion/react';
+import { type Meta } from '@storybook/react';
+
+import defaultTheme from '~/styles/theme';
+
+const meta: Meta<typeof Default> = {
+  title: 'Colors',
+  component: Default,
+};
+
+export default meta;
+
+export function Default() {
+  return (
+    <ThemeProvider theme={defaultTheme}>
+      <div css={HeadingCss}>Button</div>
+      <div css={FlexBoxCss}>
+        <div css={[(theme) => ({ backgroundColor: theme.colors.primary_200 }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.primary_100 }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.primary_50 }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.primary_300 }), BoxCss]} />
+      </div>
+      <div css={FlexBoxCss}>
+        <span>$primary.200 (main-color)</span>
+        <span>$primary.100 (button-disabled)</span>
+        <span>$primary.50 (background)</span>
+        <span>$primary.300 (button-hover)</span>
+      </div>
+      <div css={HeadingCss}>Text & Icon</div>
+      <div css={FlexBoxCss}>
+        <div css={[(theme) => ({ backgroundColor: theme.colors.secondary_200 }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.secondary_100 }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.secondary_300 }), BoxCss]} />
+      </div>
+      <div css={FlexBoxCss}>
+        <span>$secondary.200</span>
+        <span>$secondary.100 (button-disabled)</span>
+        <span>$secondary.300 (button-hover)</span>
+      </div>
+      <div css={HeadingCss}>Background</div>
+      <div css={FlexBoxCss}>
+        <div css={[(theme) => ({ backgroundColor: theme.colors.black }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.gray_500 }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.gray_400 }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.gray_300 }), BoxCss]} />
+      </div>
+      <div css={FlexBoxCss}>
+        <span>$black (text-primary)</span>
+        <span>$gray.500 (text-secondary)</span>
+        <span>$gray.400 (text-tertiary)</span>
+        <span>$gray.300 (text-disabled)</span>
+      </div>
+      <div css={FlexBoxCss}>
+        <div css={[(theme) => ({ backgroundColor: theme.colors.white }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.gray_50 }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.gray_100 }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.gray_200 }), BoxCss]} />
+      </div>
+      <div css={FlexBoxCss}>
+        <span>$white (background-primary)</span>
+        <span>$gray.50 (background-secondary)</span>
+        <span>$gray.100 (background-hover)</span>
+        <span>$gray.200 (background-tertiary)</span>
+      </div>
+      <div css={HeadingCss}>System Color</div>
+      <div css={FlexBoxCss}>
+        <div css={[(theme) => ({ backgroundColor: theme.colors.red }), BoxCss]} />
+      </div>
+      <div css={FlexBoxCss}>
+        <span>$system-red</span>
+      </div>
+      <div css={HeadingCss}>Sub Color</div>
+      <div css={FlexBoxCss}>
+        <div css={[(theme) => ({ backgroundColor: theme.colors.pink }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.purple }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.yellowgreen }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.bluegreen }), BoxCss]} />
+        <div css={[(theme) => ({ backgroundColor: theme.colors.skyblue }), BoxCss]} />
+      </div>
+      <div css={FlexBoxCss}>
+        <span>$sub-pink</span>
+        <span>$sub-purple</span>
+        <span>$secondary-yellowgreen</span>
+        <span>$secondary-bluegreen</span>
+        <span>$secondary-skyblue</span>
+      </div>
+    </ThemeProvider>
+  );
+}
+
+const HeadingCss = css`
+  margin: 30px 0 10px;
+  font-size: 30px;
+  font-weight: 700;
+  color: #2c433c;
+`;
+
+const FlexBoxCss = css`
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+
+  & > span {
+    width: 200px;
+    font-size: 12px;
+    font-weight: 600;
+    text-align: center;
+  }
+`;
+
+const BoxCss = css`
+  width: 200px;
+  height: 100px;
+  border: 2px solid rgb(10 10 12 / 8%);
+  border-radius: 15.2085px;
+`;

--- a/src/styles/color.stories.tsx
+++ b/src/styles/color.stories.tsx
@@ -88,7 +88,7 @@ export function Default() {
   );
 }
 
-const HeadingCss = css`
+const headingCss = css`
   margin: 30px 0 10px;
   font-size: 30px;
   font-weight: 700;

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -26,6 +26,6 @@ const colors = {
   yellowgreen: '#EBF7DA',
   bluegreen: '#DEF3EC',
   skyblue: '#E3F1FF',
-};
+}; as const
 
 export default colors;

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -1,0 +1,31 @@
+const colors = {
+  primary: '#638FFF',
+  primary_50: '#F2F5FF',
+  primary_100: '#D8E3FF',
+  primary_200: '#638FFF',
+  primary_300: '#4F7BEB',
+
+  secondary: '#1D2942',
+  secondary_100: '#E7E9EC',
+  secondary_200: '#1D2942',
+  secondary_300: '#111929',
+
+  gray_50: '#F4F5F9',
+  gray_100: '#EDF0F5',
+  gray_200: '#E4E7EE',
+  gray_300: '#C9CFDF',
+  gray_400: '#677189',
+  gray_500: '#394258',
+
+  black: '#17171B',
+  white: '#ffffff',
+
+  red: '#F85B81',
+  pink: '#F4E0F9',
+  purple: '#ECE7F7',
+  yellowgreen: '#EBF7DA',
+  bluegreen: '#DEF3EC',
+  skyblue: '#E3F1FF',
+};
+
+export default colors;

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -26,6 +26,6 @@ const colors = {
   yellowgreen: '#EBF7DA',
   bluegreen: '#DEF3EC',
   skyblue: '#E3F1FF',
-}; as const
+} as const;
 
 export default colors;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,7 +1,7 @@
+import colors from '~/styles/color';
+
 const theme = {
-  colors: {
-    white: '#ffffff',
-  },
+  colors,
   size: {
     maxWidth: '480px',
   },


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
컬러 디자인시스템 테마에 추가
## 🎉 변경 사항
- `color.ts` 파일을 만들어 color 디자인 시스템을 추가하였습니다. 
- `color.ts`파일을 `theme.ts`파일에 추가하여 테마에 컬러를 추가하였어요.

### 🙏 여기는 꼭 봐주세요!
- 현재 피그마에 적혀있는 color 이름들은 `$primary.200 (main-color)`와 같이 `.`을 기준으로 농도에 따라 색상이 구분되어있습니다.
하지만, `.` 기준으로 하면 css를 사용할 때에 밑과 같이 사용해야 할것 같은데 이 방법은 불편하다고 생각해 
`_`를 이용하여서 개발하였습니다. 
`_`를 사용하는 것이 괜찮다면 피그마에 있는 네이밍을 수정할 계획입니다!
  ```ts
  css={(theme) => ({ backgroundColor: theme.colors.gray['100'] })} 
  ```
- `$system-red`, `$sub-pink` 와 같은 컬러들은 농도에 따라 나뉘어져있지 않고, `system`이나 `sub`를 빼도 겹치는 것이 없는 컬러들입니다. 
이 컬러들을 사용할 때에 풀 네이밍을 사용하면 불편할 것 같다는 의견이 있어
  `system`,`sub`을 제외하고 `red`, `pink`와 같은 이름으로 개발하였습니다. 

다른 선호하시는 방법이 있다면 말씀 부탁드립니다!

### 사용 방법

1. 방법 1
```ts
<div css={[(theme) => ({ backgroundColor: theme.colors.primary_200 })]} />
```

2. 방법 2
```ts
<div css={[textCss]} />

const textCss = (theme: Theme) => css`
  max-width: ${theme.colors.primary_200};
`;
```
## 🌄 스크린샷
<img width="812" alt="스크린샷 2023-05-16 오전 1 41 48" src="https://github.com/depromeet/na-lab-client/assets/49177223/8645d3a2-8536-4e68-ba0c-a31ca2f484a9">
<img width="901" alt="스크린샷 2023-05-16 오전 1 41 58" src="https://github.com/depromeet/na-lab-client/assets/49177223/cd702211-250f-47d7-aeec-e6bb45602b91">
