### PR TITLE
eslint rule 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,6 +98,17 @@ module.exports = {
         varsIgnorePattern: '_',
       },
     ],
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'interface',
+        format: ['PascalCase'],
+      },
+      {
+        selector: 'typeAlias',
+        format: ['PascalCase'],
+      },
+    ],
 
     'react/button-has-type': 'error',
     'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,8 @@ module.exports = {
       },
     ],
 
+    'padding-line-between-statements': ['error', { blankLine: 'always', prev: '*', next: 'return' }],
+
     'prettier/prettier': 'error',
 
     'unicorn/filename-case': [

--- a/src/components/bottomSheet/BottomSheet.test.tsx
+++ b/src/components/bottomSheet/BottomSheet.test.tsx
@@ -8,6 +8,7 @@ import BottomSheet from './BottomSheet';
 
 vi.mock('framer-motion', async () => {
   const actual = await vi.importActual('framer-motion');
+
   return {
     ...(actual as object),
     AnimatePresence: ({ children }: PropsWithChildren) => (

--- a/src/components/portal/AnimatePortal.test.tsx
+++ b/src/components/portal/AnimatePortal.test.tsx
@@ -6,6 +6,7 @@ import AnimatePortal from './AnimatePortal';
 
 vi.mock('framer-motion', async () => {
   const actual = await vi.importActual('framer-motion');
+
   return {
     ...(actual as object),
     AnimatePresence: ({ children }: PropsWithChildren) => (

--- a/src/features/createSurvey/CreateSurvey.tsx
+++ b/src/features/createSurvey/CreateSurvey.tsx
@@ -13,6 +13,7 @@ const CreateSurvey = () => {
   const handleNewItemAdd = () => {
     setCardItems((prev) => {
       const newId = prev.length;
+
       return [
         ...prev,
         {

--- a/src/hooks/common/useDebounce.ts
+++ b/src/hooks/common/useDebounce.ts
@@ -17,6 +17,7 @@ const useDebounce = (cb: () => void, ms: number): (() => void) => {
     const newTimer = setTimeout(cb, ms);
     timer.current = newTimer;
   };
+
   return dispatchDebounce;
 };
 

--- a/src/hooks/lifeCycle/useDidUpdate.ts
+++ b/src/hooks/lifeCycle/useDidUpdate.ts
@@ -6,6 +6,7 @@ const useDidUpdate = (callback: EffectCallback, dependencyList: DependencyList) 
   useEffect(() => {
     if (!didMountRef.current) {
       didMountRef.current = true;
+
       return;
     }
 


### PR DESCRIPTION
## 🎉 변경 사항

2개의 eslint 룰을 추가했어요

- 인터페이스와 타입에 `PascalCase`로 네이밍 컨벤션 룰을 추가헀어요

https://typescript-eslint.io/rules/naming-convention/#enforce-that-all-variables-functions-and-properties-follow-are-camelcase


- padding line between statements rule을 추가해, `return` 이전에 공백 줄을 설정하고 적용했어요

https://eslint.org/docs/latest/rules/padding-line-between-statements

> 요 룰은 취향이 갈릴 거 같은데 여러분들은 어떻게 생각하시나요?
