### PR TITLE
Layout 적용 및 23px Layout 컴포넌트

### DIFF
--- a/src/components/layout/LayoutPaddingTo23.tsx
+++ b/src/components/layout/LayoutPaddingTo23.tsx
@@ -1,0 +1,26 @@
+import { type PropsWithChildren } from 'react';
+import { css } from '@emotion/react';
+
+/**
+ * @description `_app`에서 적용된 `padding: 0 16px`에서 추가적으로 7px을 더해 23px로 만드는 용의 wrapper 입니다
+ * @example
+ * ```tsx
+ * // index.page.tsx
+ * import LayoutPaddingTo23 from '~/components/layout/LayoutPaddingTo23';
+ *
+ * export default function Index() {
+ *  return <div>foo</div>;
+ * }
+ *
+ * Index.getLayout = (page) => <LayoutPaddingTo23>{page}</LayoutPaddingTo23>;
+ * ```
+ */
+const LayoutPaddingTo23 = ({ children }: PropsWithChildren) => {
+  return <div css={layoutCss}>{children}</div>;
+};
+
+export default LayoutPaddingTo23;
+
+const layoutCss = css`
+  padding: 0 7px;
+`;

--- a/src/components/layout/LayoutPaddingTo23.tsx
+++ b/src/components/layout/LayoutPaddingTo23.tsx
@@ -6,13 +6,14 @@ import { css } from '@emotion/react';
  * @example
  * ```tsx
  * // index.page.tsx
+ * import { type ReactElement } from 'react';
  * import LayoutPaddingTo23 from '~/components/layout/LayoutPaddingTo23';
  *
  * export default function Index() {
  *  return <div>foo</div>;
  * }
  *
- * Index.getLayout = (page) => <LayoutPaddingTo23>{page}</LayoutPaddingTo23>;
+ * Index.getLayout = (page: ReactElement) => <LayoutPaddingTo23>{page}</LayoutPaddingTo23>;
  * ```
  */
 const LayoutPaddingTo23 = ({ children }: PropsWithChildren) => {

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -60,4 +60,5 @@ const defaultLayoutCss = (theme: Theme) => css`
   max-width: ${theme.size.maxWidth};
   min-height: 100vh;
   margin: 0 auto;
+  padding: 0 16px;
 `;

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,3 +1,9 @@
+import { type ReactElement } from 'react';
+
+import LayoutPaddingTo23 from '~/components/layout/LayoutPaddingTo23';
+
 export default function Home() {
   return <div>home</div>;
 }
+
+Home.getLayout = (page: ReactElement) => <LayoutPaddingTo23>{page}</LayoutPaddingTo23>;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

- 좌우 패딩 레이아웃 적용

## 🎉 변경 사항

- 기본 좌우 패딩을 `16px`로 `_app`에 적용했어요

- 몇 페이지들에서 좌우 패딩이 `23px`인 요구사항이 있어요.
이에 대응하기 위해 이야기를 나눴던 방향으로 `LayoutPaddingTo23` 컴포넌트를 만들었어요

### 🙏 여기는 꼭 봐주세요!

- 최선인지는 고민이 됩니다 🤔 

### 사용 방법

- 좌우 패딩이 `23px`인 곳에서는 다음과 같이 사용할 수 있어요

```tsx
import { type ReactElement } from 'react';

import LayoutPaddingTo23 from '~/components/layout/LayoutPaddingTo23';

export default function Home() {
  return <div>home</div>;
}

Home.getLayout = (page: ReactElement) => <LayoutPaddingTo23>{page}</LayoutPaddingTo23>;
```

- 좌우 패딩이 `16px`인 곳에서는 사용하지 않아도 돼요

## 참고

https://nextjs.org/docs/pages/building-your-application/routing/pages-and-layouts