### PR TITLE
review - 협업 경험 step

### DIFF
--- a/src/components/button/CircleButton.tsx
+++ b/src/components/button/CircleButton.tsx
@@ -1,5 +1,5 @@
 import { type ComponentProps, forwardRef, type Ref } from 'react';
-import { css, type Theme } from '@emotion/react';
+import { css, type Theme, useTheme } from '@emotion/react';
 
 import ArrowIcon from '../icons/ArrowIcon';
 import XIcon from '../icons/XIcon';
@@ -37,6 +37,11 @@ const buttonCss = (theme: Theme) => css`
   &:hover {
     background-color: ${theme.colors.gray_100};
   }
+
+  &:disabled {
+    cursor: not-allowed;
+    background-color: ${theme.colors.gray_50};
+  }
 `;
 
 type CircleButtonPropsWithoutChildren = Omit<ComponentProps<typeof CircleButton>, 'children'>;
@@ -44,19 +49,32 @@ type ArrowIconDirection = Pick<ComponentProps<typeof ArrowIcon>, 'direction'>;
 
 export const ArrowCircleButton = ({
   direction = 'left',
+  disabled,
   ...rest
 }: CircleButtonPropsWithoutChildren & ArrowIconDirection) => {
+  const iconColor = useDisabledIconColor(disabled);
+
   return (
-    <CircleButton {...rest}>
-      <ArrowIcon direction={direction} size={28} viewBox="0 0 24 24" />
+    <CircleButton disabled={disabled} {...rest}>
+      <ArrowIcon direction={direction} color={iconColor} size={28} viewBox="0 0 24 24" />
     </CircleButton>
   );
 };
 
-export const XCircleButton = (props: CircleButtonPropsWithoutChildren) => {
+export const XCircleButton = ({ disabled, ...rest }: CircleButtonPropsWithoutChildren) => {
+  const iconColor = useDisabledIconColor(disabled);
+
   return (
-    <CircleButton {...props}>
-      <XIcon size={28} viewBox="0 0 24 24" />
+    <CircleButton {...rest}>
+      <XIcon size={28} color={iconColor} viewBox="0 0 24 24" />
     </CircleButton>
   );
+};
+
+const useDisabledIconColor = (disabled?: boolean) => {
+  const theme = useTheme();
+  const disabledIconColor = theme.colors.gray_300;
+
+  // NOTE: undefined는 기본 색상을 뜻합니다.
+  return disabled ? disabledIconColor : undefined;
 };

--- a/src/features/review/BottomNavigation.tsx
+++ b/src/features/review/BottomNavigation.tsx
@@ -7,9 +7,9 @@ import { ArrowCircleButton } from '~/components/button/CircleButton';
 import { fixedBottomCss } from './style';
 
 interface Props {
-  onBackClick: MouseEventHandler<HTMLButtonElement>;
+  onBackClick?: MouseEventHandler<HTMLButtonElement>;
   isBackDisabled?: boolean;
-  onNextClick: MouseEventHandler<HTMLButtonElement>;
+  onNextClick?: MouseEventHandler<HTMLButtonElement>;
   isNextDisabled?: boolean;
 }
 

--- a/src/features/review/BottomNavigation.tsx
+++ b/src/features/review/BottomNavigation.tsx
@@ -8,14 +8,15 @@ import { fixedBottomCss } from './style';
 
 interface Props {
   onBackClick: MouseEventHandler<HTMLButtonElement>;
+  isBackDisabled?: boolean;
   onNextClick: MouseEventHandler<HTMLButtonElement>;
   isNextDisabled?: boolean;
 }
 
-const BottomNavigation = ({ onBackClick, onNextClick, isNextDisabled }: Props) => {
+const BottomNavigation = ({ onBackClick, isBackDisabled, onNextClick, isNextDisabled }: Props) => {
   return (
     <div css={wrapperCss}>
-      <ArrowCircleButton onClick={onBackClick} />
+      <ArrowCircleButton onClick={onBackClick} disabled={isBackDisabled} />
       <Button onClick={onNextClick} disabled={isNextDisabled}>
         다음
       </Button>

--- a/src/features/review/steps/Cowork.tsx
+++ b/src/features/review/steps/Cowork.tsx
@@ -1,0 +1,157 @@
+import { type ChangeEventHandler, type Dispatch, type SetStateAction } from 'react';
+import { css, type Theme } from '@emotion/react';
+import { m } from 'framer-motion';
+
+import { defaultFadeInVariants } from '~/constants/motions';
+import { HEAD_2_BOLD, HEAD_2_REGULAR } from '~/styles/typo';
+
+import BottomNavigation from '../BottomNavigation';
+import QuestionHeader from '../QuestionHeader';
+import { type StepProps } from './type';
+
+// TODO: API 개발 이후 수정
+const MOCK_NAME = '예진';
+
+const RADIO_NAME = 'isCowork';
+
+interface Props extends StepProps {
+  isCoworked: boolean | null;
+  setIsCoworked: Dispatch<SetStateAction<boolean | null>>;
+}
+
+const Cowork = ({ prev, next, isCoworked, setIsCoworked }: Props) => {
+  const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setIsCoworked(Boolean(e.target.value));
+  };
+
+  return (
+    <>
+      <QuestionHeader title={`당신은 ${MOCK_NAME}님과 협업한 경험이 있나요?`} />
+
+      <m.section css={sectionCss} variants={defaultFadeInVariants} initial="initial" animate="animate" exit="exit">
+        <div css={outerCircleCss}>
+          <m.div css={innerCircleCss(isCoworked)}>
+            <label css={[inputLabelCss, yesLabelCss]}>
+              <input type="radio" name={RADIO_NAME} value="yes" onChange={onChange} />
+              <span>네, 있어요</span>
+            </label>
+
+            <label css={[inputLabelCss, noLabelCss]}>
+              <input type="radio" name={RADIO_NAME} value="" onChange={onChange} />
+              <span>없어요</span>
+            </label>
+          </m.div>
+        </div>
+      </m.section>
+
+      <BottomNavigation isBackDisabled onBackClick={prev} isNextDisabled={isCoworked === null} onNextClick={next} />
+    </>
+  );
+};
+
+export default Cowork;
+
+const sectionCss = css`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: center;
+
+  padding-bottom: 192px;
+`;
+
+const outerCircleCss = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 310px;
+  height: 310px;
+
+  background-color: #fafbff;
+  border-radius: 50%;
+  box-shadow: inset 0 0 27.3653px -6.8413px rgb(205 216 242 / 50%);
+`;
+
+type IsCoworked = boolean | null;
+
+const innerCircleCss = (isCoworked: IsCoworked) => css`
+  position: relative;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 166px;
+  height: 166px;
+
+  background-clip: content-box, border-box;
+  background-origin: border-box;
+  border: 2px solid transparent;
+  border-radius: 50%;
+
+  ${isCoworked === null && defaultCss};
+  ${isCoworked === true && isCoworkedCss};
+  ${isCoworked === false && notCoworkedCss};
+`;
+
+const defaultCss = css`
+  background-image: linear-gradient(#fafbff, #fafbff), linear-gradient(270deg, #638fff 0.2%, rgb(49 206 255 / 55%) 100%);
+`;
+
+const isCoworkedCss = css`
+  background-image: linear-gradient(#fafbff, #fafbff), linear-gradient(180deg, #638fff 0.2%, rgb(49 206 255 / 55%) 100%);
+  box-shadow: 0 0 20.524px -14.8229px #415e9c;
+`;
+
+const notCoworkedCss = css`
+  background-image: linear-gradient(#fafbff, #fafbff), linear-gradient(180deg, #1d2942 0.2%, #9eb9ff 100%);
+  box-shadow: 0 0 20.524px -14.8229px #415e9c;
+`;
+
+const inputLabelCss = (theme: Theme) => css`
+  ${HEAD_2_REGULAR}
+
+  cursor: pointer;
+  position: absolute;
+
+  & > input {
+    display: none;
+    appearance: none;
+  }
+
+  & > span {
+    padding: 7px 13px;
+
+    color: ${theme.colors.gray_400};
+
+    background-color: ${theme.colors.white};
+    border-radius: 24px;
+    box-shadow: 0 0 11px -18px red;
+
+    transition: background-color 0.3s ${theme.transition.defaultEasing}, color 0.3s ${theme.transition.defaultEasing};
+  }
+`;
+
+const yesLabelCss = (theme: Theme) => css`
+  top: -7px;
+
+  & > input:checked + span {
+    ${HEAD_2_BOLD}
+
+    color: ${theme.colors.white};
+    background-color: ${theme.colors.primary_200};
+  }
+`;
+
+const noLabelCss = (theme: Theme) => css`
+  bottom: -7px;
+
+  & > input:checked + span {
+    ${HEAD_2_BOLD}
+
+    color: ${theme.colors.white};
+    background-color: ${theme.colors.gray_500};
+  }
+`;

--- a/src/features/review/steps/ReviewSteps.stories.tsx
+++ b/src/features/review/steps/ReviewSteps.stories.tsx
@@ -1,4 +1,8 @@
-import IntroStep from './Intro';
+import { useState } from 'react';
+import { css } from '@emotion/react';
+
+import Cowork from './Cowork';
+import Intro from './Intro';
 
 const meta = {
   title: 'Review Steps',
@@ -6,6 +10,26 @@ const meta = {
 
 export default meta;
 
-export function Intro() {
-  return <IntroStep />;
+const mainCss = css`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+`;
+
+export function 인트로() {
+  return (
+    <main css={mainCss}>
+      <Intro />
+    </main>
+  );
+}
+
+export function 협업_경험() {
+  const [isCoworked, setIsCoworked] = useState<null | boolean>(null);
+
+  return (
+    <main css={mainCss}>
+      <Cowork isCoworked={isCoworked} setIsCoworked={setIsCoworked} />
+    </main>
+  );
 }

--- a/src/pages/review/[token].page.tsx
+++ b/src/pages/review/[token].page.tsx
@@ -1,22 +1,46 @@
+import { useState } from 'react';
+import dynamic from 'next/dynamic';
+import { css } from '@emotion/react';
 import { AnimatePresence } from 'framer-motion';
 
 import Intro from '~/features/review/steps/Intro';
 import useInjectedElementStep from '~/hooks/step/useInjectedElementStep';
+
+const Cowork = dynamic(() => import('~/features/review/steps/Cowork'), { ssr: false });
 
 const ReviewPage = () => {
   // TODO: 이후 token 검증 및 조회 로직 추가
   // const router = useRouter();
   // const { token } = router.query;
 
+  const { isCoworked, setIsCoworked } = useIsCowork();
+
   const { currentElement } = useInjectedElementStep({
-    elements: [<Intro key="intro" />, <div key="div">2</div>, <div key="div2">3</div>],
+    elements: [
+      <Intro key="intro" />,
+      <Cowork key="cowork" isCoworked={isCoworked} setIsCoworked={setIsCoworked} />,
+      <div key="div">2</div>,
+      <div key="div2">3</div>,
+    ],
   });
 
   return (
-    <main>
+    <main css={mainCss}>
       <AnimatePresence mode="wait">{currentElement}</AnimatePresence>
     </main>
   );
 };
 
 export default ReviewPage;
+
+const mainCss = css`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+`;
+
+const useIsCowork = () => {
+  const [isCoworked, setIsCoworked] = useState<null | boolean>(null);
+
+  return { isCoworked, setIsCoworked };
+};


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

- 리뷰어의 협업 경험 단계

## 🎉 변경 사항

- icon circle button의 disabled를 대응했어요 3bb80f974ee148c55d14f888642308cd4ab2aff5

- review 페이지에서 사용하는 bottom navigation의 인터페이스를 변경했어요
  - 이전 버튼도 disabled 될 수 있어서 추가했어요

- 협업 경험을 확인하는 스탭을 만들었어요
  - 그레디언트 + 원형 보더를 만드느라 생각보다 시간이 오래걸렸네요 ㅠ
  - 그레디언트에 transition 속성이 동작하지 않아 어떻게 멋있게 바꿀 수 있을지는 연구가 필요합니다 ...

### 🙏 여기는 꼭 봐주세요!

https://github.com/depromeet/na-lab-client/blob/e4736e5596087fa90560b346441be82179711d88/src/features/review/steps/Cowork.tsx#L77

이 부분을 원래는

```tsx
type IsCoworked = Pick<Props, 'isCoworked'>;
```

처럼 했었는데, 사용처에서 타입 에러가 발생하더라구요 🤔 

---

https://github.com/depromeet/na-lab-client/blob/e4736e5596087fa90560b346441be82179711d88/src/pages/review/%5Btoken%5D.page.tsx#L11-L46

1. 데이터 각각을 `pages/review/[token]` 페이지에서 다루고,
2. 각 스텝에서 데이터를 가공하고
3. 모아진 데이터를 마지막 스텝에서 전송하고 끝내는 플로우로 생각하고 있는데

더 나은 방향이 있을지 고민되네요 🤔 

## 🌄 스크린샷

https://github.com/depromeet/na-lab-client/assets/26461307/08580965-5cbe-4af1-b6b0-eaabd8de363a


## 📚 참고

https://velog.io/@dltjsgho/css-border%EC%97%90-%EA%B7%B8%EB%9D%BC%EB%8D%B0%EC%9D%B4%EC%85%98-%EB%84%A3%EA%B8%B0