### PR TITLE
로컬스토리지 hook생성

### DIFF
--- a/src/hooks/storage/useLocalStorage.test.tsx
+++ b/src/hooks/storage/useLocalStorage.test.tsx
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { describe, expect, test, vitest } from 'vitest';
+
+import useLocalStorage from '~/hooks/storage/useLocalStorage';
+
+const STORAGE_KEY = 'storage_key';
+
+describe('hooks/storage/useLocalStorage', () => {
+  test('초기값 리턴 확인', () => {
+    const initialState = { a: 1, b: 2 };
+    const { result } = renderHook(() => useLocalStorage(STORAGE_KEY, initialState));
+
+    expect(result.current[0]).toEqual(initialState);
+  });
+
+  test('로컬스토리지에 초기값이 정상적으로 저장되어있는지 확인', () => {
+    const initialState = { a: 1, b: 2 };
+    const { result } = renderHook(() => useLocalStorage(STORAGE_KEY, { a: 1, b: 2 }));
+
+    act(() => {
+      result.current[1](initialState);
+    });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toEqual(JSON.stringify(initialState));
+  });
+
+  test('로컬스토리지에 새로운 값으로 재설정', () => {
+    const initialState = { a: 1, b: 2 };
+    const { result } = renderHook(() => useLocalStorage(STORAGE_KEY, initialState));
+    const newValue = { a: 2, b: 5 };
+    act(() => {
+      result.current[1](newValue);
+    });
+    expect(result.current[0]).toEqual(newValue);
+    expect(localStorage.getItem(STORAGE_KEY)).toEqual(JSON.stringify(newValue));
+  });
+
+  test('로컬스토리지의 setItem이 한번 호출되었는지 확인', () => {
+    // do not prepare the initial state on every render except the first
+    const spyStorage = vitest.spyOn(Storage.prototype, 'setItem');
+
+    const initialState = { a: 1, b: 2 };
+    const { result } = renderHook(() => useLocalStorage(STORAGE_KEY, initialState));
+    const newValue = { a: 2, b: 5 };
+    act(() => {
+      result.current[1](newValue);
+    });
+    expect(result.current[0]).toEqual(newValue);
+    expect(spyStorage).toHaveBeenCalledTimes(1);
+    spyStorage.mockReset();
+  });
+});

--- a/src/hooks/storage/useLocalStorage.ts
+++ b/src/hooks/storage/useLocalStorage.ts
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+
+/**
+ * @description 페이지 새로 고침을 통해 상태가 유지되도록 로컬 저장소에 동기화합니다.
+ *
+ * @param key 로컬 저장소에 저장될 키
+ * @param initialValue 초기 값
+ * @returns [storedValue, setValue] - 로컬 저장소에 저장된 값, 저장 함수
+ */
+function useLocalStorage<T>(key: string, initialValue: T) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+    try {
+      const item = window.localStorage.getItem(key);
+
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.log(error);
+
+      return initialValue;
+    }
+  });
+
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      setStoredValue(valueToStore);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  return [storedValue, setValue] as const;
+}
+
+export default useLocalStorage;

--- a/src/hooks/storage/useLocalStorage.ts
+++ b/src/hooks/storage/useLocalStorage.ts
@@ -19,7 +19,7 @@ function useLocalStorage<T>(key: string, initialValue: T) {
 
       return item ? JSON.parse(item) : initialValue;
     } catch (error) {
-      console.log(error);
+      console.error(error);
 
       return initialValue;
     }
@@ -33,7 +33,7 @@ function useLocalStorage<T>(key: string, initialValue: T) {
         window.localStorage.setItem(key, JSON.stringify(valueToStore));
       }
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
   };
 


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
페이지 새로 고침을 통해 상태가 유지되도록 할때 사용되는 로컬스토리지 hook을 생성

- 페이지 새로 고침을 통해 상태가 유지되도록 로컬 저장소에 동기화
- 서버가 필요한 환경에서는 로컬 스토리지 API를 사용할 수 없으므로  `window !== "undefined".` 확인

## 🎉 변경 사항
- useLocalStorage 커스텀 훅 생성
- 테스트 코드 작성

### 사용 방법
```ts
 const [name, setName] = useLocalStorage("name", "수미");
```
