### PR TITLE
review - 소프트 스킬 선택 스탭

### DIFF
--- a/src/components/graphic/softskills/Softskill.tsx
+++ b/src/components/graphic/softskills/Softskill.tsx
@@ -12,3 +12,5 @@ const Softskill = ({ name }: Props) => {
 };
 
 export default Softskill;
+
+export const softskillList: Softskills[] = Object.keys(softskills) as Softskills[];

--- a/src/components/pill/Pill.tsx
+++ b/src/components/pill/Pill.tsx
@@ -3,6 +3,8 @@ import { css, type Interpolation, type Theme } from '@emotion/react';
 
 import { BODY_1, HEAD_2_REGULAR } from '~/styles/typo';
 
+import { bluegreenCss, pinkCss, purpleCss, skyblueCss, yellowgreenCss } from './style';
+
 type Size = 'large' | 'medium';
 type Color = 'default' | 'bluegreen' | 'pink' | 'skyblue' | 'yellowgreen' | 'purple';
 
@@ -44,46 +46,6 @@ const SIZE_STYLE: Record<Size, Interpolation<Theme>> = {
 
 const defaultCss = css`
   background-color: #f4f5f9;
-`;
-
-const bluegreenCss = (theme: Theme) => css`
-  background-color: ${theme.colors.bluegreen};
-
-  & > svg {
-    fill: #b9ded2;
-  }
-`;
-
-const pinkCss = (theme: Theme) => css`
-  background-color: ${theme.colors.pink};
-
-  & > svg {
-    fill: #e5bfef;
-  }
-`;
-
-const skyblueCss = (theme: Theme) => css`
-  background-color: ${theme.colors.skyblue};
-
-  & > svg {
-    fill: #bfdbf6;
-  }
-`;
-
-const yellowgreenCss = (theme: Theme) => css`
-  background-color: ${theme.colors.yellowgreen};
-
-  & > svg {
-    fill: #cde7ac;
-  }
-`;
-
-const purpleCss = (theme: Theme) => css`
-  background-color: ${theme.colors.purple};
-
-  & > svg {
-    fill: #d3c3f4;
-  }
 `;
 
 const COLOR_STYLE: Record<Color, Interpolation<Theme>> = {

--- a/src/components/pill/style.ts
+++ b/src/components/pill/style.ts
@@ -1,0 +1,41 @@
+import { css, type Theme } from '@emotion/react';
+
+export const bluegreenCss = (theme: Theme) => css`
+  background-color: ${theme.colors.bluegreen};
+
+  & > svg {
+    fill: #b9ded2;
+  }
+`;
+
+export const pinkCss = (theme: Theme) => css`
+  background-color: ${theme.colors.pink};
+
+  & > svg {
+    fill: #e5bfef;
+  }
+`;
+
+export const skyblueCss = (theme: Theme) => css`
+  background-color: ${theme.colors.skyblue};
+
+  & > svg {
+    fill: #bfdbf6;
+  }
+`;
+
+export const yellowgreenCss = (theme: Theme) => css`
+  background-color: ${theme.colors.yellowgreen};
+
+  & > svg {
+    fill: #cde7ac;
+  }
+`;
+
+export const purpleCss = (theme: Theme) => css`
+  background-color: ${theme.colors.purple};
+
+  & > svg {
+    fill: #d3c3f4;
+  }
+`;

--- a/src/features/review/BottomNavigation.tsx
+++ b/src/features/review/BottomNavigation.tsx
@@ -15,12 +15,15 @@ interface Props {
 
 const BottomNavigation = ({ onBackClick, isBackDisabled, onNextClick, isNextDisabled }: Props) => {
   return (
-    <div css={wrapperCss}>
-      <ArrowCircleButton onClick={onBackClick} disabled={isBackDisabled} />
-      <Button onClick={onNextClick} disabled={isNextDisabled} css={buttonCss}>
-        다음
-      </Button>
-    </div>
+    <>
+      <div css={wrapperCss}>
+        <ArrowCircleButton onClick={onBackClick} disabled={isBackDisabled} />
+        <Button onClick={onNextClick} disabled={isNextDisabled} css={buttonCss}>
+          다음
+        </Button>
+      </div>
+      <div css={wrapperRemainerCss} />
+    </>
   );
 };
 
@@ -43,4 +46,9 @@ const wrapperCss = (theme: Theme) => css`
 
 const buttonCss = css`
   padding: 15.5px 68px;
+`;
+
+const wrapperRemainerCss = css`
+  flex-shrink: 0;
+  height: 104px;
 `;

--- a/src/features/review/steps/Cowork.tsx
+++ b/src/features/review/steps/Cowork.tsx
@@ -57,8 +57,6 @@ const sectionCss = css`
   flex-grow: 1;
   align-items: center;
   justify-content: center;
-
-  padding-bottom: 192px;
 `;
 
 const outerCircleCss = css`

--- a/src/features/review/steps/ReviewSteps.stories.tsx
+++ b/src/features/review/steps/ReviewSteps.stories.tsx
@@ -1,8 +1,11 @@
 import { useState } from 'react';
 import { css } from '@emotion/react';
 
+import { type Softskills } from '~/components/graphic/softskills/type';
+
 import Cowork from './Cowork';
 import Intro from './Intro';
+import Softskill from './Softskill';
 
 const meta = {
   title: 'Review Steps',
@@ -30,6 +33,16 @@ export function 협업_경험() {
   return (
     <main css={mainCss}>
       <Cowork isCoworked={isCoworked} setIsCoworked={setIsCoworked} />
+    </main>
+  );
+}
+
+export function 소프트_스킬() {
+  const [selectedSoftskills, setSelectedSoftskills] = useState<Softskills[]>([]);
+
+  return (
+    <main css={mainCss}>
+      <Softskill selectedSoftskills={selectedSoftskills} setSelectedSoftskills={setSelectedSoftskills} />
     </main>
   );
 }

--- a/src/features/review/steps/Softskill.tsx
+++ b/src/features/review/steps/Softskill.tsx
@@ -1,0 +1,78 @@
+import { type ChangeEventHandler, type Dispatch, type SetStateAction } from 'react';
+import { css } from '@emotion/react';
+
+import { softskillList } from '~/components/graphic/softskills/Softskill';
+import { type Softskills } from '~/components/graphic/softskills/type';
+
+import BottomNavigation from '../BottomNavigation';
+import QuestionHeader from '../QuestionHeader';
+import PillCheckbox from './softskill/PillCheckbox';
+import { type StepProps } from './type';
+
+interface Props extends StepProps {
+  selectedSoftskills: Softskills[];
+  setSelectedSoftskills: Dispatch<SetStateAction<Softskills[]>>;
+}
+
+const MAX_LENGTH = 5;
+
+const Softskill = ({ prev, next, selectedSoftskills, setSelectedSoftskills }: Props) => {
+  const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const clickedSoftskill = e.target.value as Softskills;
+
+    if (!e.target.checked) {
+      setSelectedSoftskills((prevSoftskills) => prevSoftskills.filter((softskill) => softskill !== clickedSoftskill));
+
+      return;
+    }
+
+    if (selectedSoftskills.length >= MAX_LENGTH) {
+      e.target.checked = false;
+
+      return;
+    }
+
+    if (e.target.checked) {
+      setSelectedSoftskills((prevSoftskills) => [...prevSoftskills, clickedSoftskill]);
+    }
+  };
+
+  return (
+    <>
+      <QuestionHeader
+        title="당신이 생각하는 예진 님은 어떤 이미지가 돋보이나요?"
+        subTitle="키워드를 최대 5개까지 선택해주세요."
+      />
+      <section css={sectionCss}>
+        {softskillList.map((softskill) => (
+          <PillCheckbox
+            key={softskill}
+            graphicName={softskill}
+            name={softskill.replace('_', ' ')}
+            onChange={onChange}
+          />
+        ))}
+      </section>
+      <BottomNavigation onBackClick={prev} isNextDisabled={!Boolean(selectedSoftskills.length)} onNextClick={next} />
+    </>
+  );
+};
+
+export default Softskill;
+
+const sectionCss = css`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+`;
+
+// TODO: 순서에 따라 색상 부여
+// type Color = 'bluegreen' | 'pink' | 'skyblue' | 'yellowgreen' | 'purple';
+// const COLOR_ORDER: Color[] = ['bluegreen', 'pink', 'skyblue', 'yellowgreen', 'purple'];
+// const IS_COLOR_CHECKED: Record<Color, boolean> = {
+//   bluegreen: false,
+//   pink: false,
+//   skyblue: false,
+//   yellowgreen: false,
+//   purple: false,
+// };

--- a/src/features/review/steps/softskill/PillCheckbox.tsx
+++ b/src/features/review/steps/softskill/PillCheckbox.tsx
@@ -1,0 +1,38 @@
+import { type ComponentProps, type InputHTMLAttributes } from 'react';
+import { css, type Theme } from '@emotion/react';
+
+import Softskill from '~/components/graphic/softskills/Softskill';
+import Pill from '~/components/pill/Pill';
+import { skyblueCss } from '~/components/pill/style';
+
+type InputAttributes = InputHTMLAttributes<HTMLInputElement>;
+
+interface Props extends InputAttributes {
+  graphicName: ComponentProps<typeof Softskill>['name'];
+  name: string;
+}
+
+const PillCheckbox = ({ graphicName, name, ...rest }: Props) => {
+  return (
+    <label css={labelCss}>
+      <input type="checkbox" value={graphicName} {...rest} />
+      <Pill color="default">
+        <Softskill name={graphicName} />
+        {name}
+      </Pill>
+    </label>
+  );
+};
+
+export default PillCheckbox;
+
+const labelCss = (theme: Theme) => css`
+  & > input {
+    display: none;
+    appearance: none;
+  }
+
+  & > input:checked + span {
+    ${skyblueCss(theme)}
+  }
+`;

--- a/src/pages/review/[token].page.tsx
+++ b/src/pages/review/[token].page.tsx
@@ -3,10 +3,12 @@ import dynamic from 'next/dynamic';
 import { css } from '@emotion/react';
 import { AnimatePresence } from 'framer-motion';
 
+import { type Softskills } from '~/components/graphic/softskills/type';
 import Intro from '~/features/review/steps/Intro';
 import useInjectedElementStep from '~/hooks/step/useInjectedElementStep';
 
 const Cowork = dynamic(() => import('~/features/review/steps/Cowork'), { ssr: false });
+const Softskill = dynamic(() => import('~/features/review/steps/Softskill'), { ssr: false });
 
 const ReviewPage = () => {
   // TODO: 이후 token 검증 및 조회 로직 추가
@@ -14,11 +16,17 @@ const ReviewPage = () => {
   // const { token } = router.query;
 
   const { isCoworked, setIsCoworked } = useIsCowork();
+  const { selectedSoftskills, setSelectedSoftskills } = useSoftskills();
 
   const { currentElement } = useInjectedElementStep({
     elements: [
       <Intro key="intro" />,
       <Cowork key="cowork" isCoworked={isCoworked} setIsCoworked={setIsCoworked} />,
+      <Softskill
+        key="softskill"
+        selectedSoftskills={selectedSoftskills}
+        setSelectedSoftskills={setSelectedSoftskills}
+      />,
       <div key="div">2</div>,
       <div key="div2">3</div>,
     ],
@@ -43,4 +51,10 @@ const useIsCowork = () => {
   const [isCoworked, setIsCoworked] = useState<null | boolean>(null);
 
   return { isCoworked, setIsCoworked };
+};
+
+const useSoftskills = () => {
+  const [selectedSoftskills, setSelectedSoftskills] = useState<Softskills[]>([]);
+
+  return { selectedSoftskills, setSelectedSoftskills };
 };


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

- 소프트 스킬 스탭

## 🎉 변경 사항

- 소프트 스킬 스탭을 개발했어요
  - 모든 스탭의 데이터 관리를 위해 `review/[token].page.tsx` 에서는 상태만을 전달하고 각 데이터 가공은 스탭 단에서 하는 방법을 택했어요
    - 데이터 가공을 위한 `onChange` 같은 콜백을 만들어서 전달할 수도 있겠지만, 가독성 측면과 유지보수성 측면에서 각 스탭에서 다루는 게 좋다고 판단했어요

- `review` 페이지에 종속적으로 사용될 `PillCheckbox` 컴포넌트를 만들었어요.

- `review` feature에 있는 `BottomNavigation`의 스크롤 높이를 보존하기 위해 `remainer div`를 추가했어요
  - 관련해서 `Cowork` 스탭의 스타일링을 수정했어요


### 🙏 여기는 꼭 봐주세요!

- 체크되는 순서에 따라 색상이 변경되어야 하는 요구 사항을 구현하지 못했어요
  - context, props, onChange 에서 동적으로 주입하는 방법을 시도해 봤는데 만족스러운 결과를 얻지 못했어요
  다음에 시간 될 때 페어프로그래밍 해보면 좋을거 같습니다 ... 😢 


## 🌄 스크린샷


https://github.com/depromeet/na-lab-client/assets/26461307/36fa4037-787b-4d29-af43-af8689937a68

