### PR TITLE
review - 소프트 스킬 스탭 토스트 적용, `Toast.Text` children 타입 변경

### DIFF
--- a/src/components/graphic/softskills/결단력_있는.tsx
+++ b/src/components/graphic/softskills/결단력_있는.tsx
@@ -8,8 +8,8 @@ export const 결단력_있는 = ({ color = '#C9CFDF' }: ComponentProps<typeof Sv
     <Svg size={20} isUsingFill color={color}>
       <circle cx="10" cy="10" r="5" />
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M10 20C15.5228 20 20 15.5228 20 10C20 4.47715 15.5228 0 10 0C4.47715 0 0 4.47715 0 10C0 15.5228 4.47715 20 10 20ZM10 17C13.866 17 17 13.866 17 10C17 6.13401 13.866 3 10 3C6.13401 3 3 6.13401 3 10C3 13.866 6.13401 17 10 17Z"
       />
     </Svg>

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react';
 import { css, type Theme } from '@emotion/react';
 
 import { type ToastProps } from '~/store/toast';
@@ -21,7 +22,7 @@ const toastCss = css`
   border-radius: 44px;
 `;
 
-const Text = ({ children }: { children: string }) => {
+const Text = ({ children }: { children: ReactNode }) => {
   return <span css={toastTextCss}>{children}</span>;
 };
 

--- a/src/features/review/steps/Softskill.tsx
+++ b/src/features/review/steps/Softskill.tsx
@@ -3,6 +3,9 @@ import { css } from '@emotion/react';
 
 import { softskillList } from '~/components/graphic/softskills/Softskill';
 import { type Softskills } from '~/components/graphic/softskills/type';
+import WarningIcon from '~/components/icons/WarningIcon';
+import Toast from '~/components/toast/Toast';
+import useToast from '~/components/toast/useToast';
 
 import BottomNavigation from '../BottomNavigation';
 import QuestionHeader from '../QuestionHeader';
@@ -17,6 +20,8 @@ interface Props extends StepProps {
 const MAX_LENGTH = 5;
 
 const Softskill = ({ prev, next, selectedSoftskills, setSelectedSoftskills }: Props) => {
+  const { fireToast } = useToast();
+
   const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     const clickedSoftskill = e.target.value as Softskills;
 
@@ -28,6 +33,16 @@ const Softskill = ({ prev, next, selectedSoftskills, setSelectedSoftskills }: Pr
 
     if (selectedSoftskills.length >= MAX_LENGTH) {
       e.target.checked = false;
+
+      fireToast({
+        content: (
+          <>
+            <WarningIcon />
+            <Toast.Text>키워드는 {MAX_LENGTH}개까지 선택할 수 있어요</Toast.Text>
+          </>
+        ),
+        higherThanCTA: true,
+      });
 
       return;
     }


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

- close #173 

## 🎉 변경 사항

- 소프트 스킬 스탭에서 max개 이상으로 누를 시 토스트를 띄웠어요

- `Toast.Text`의 children 타입을 `string`에서 `ReactNode`로 바꿨어요

```diff
const MAX_LENGTH = 5;

...
fireToast({
        content: (
          <>
            <WarningIcon />
-            <Toast.Text>키워드는 {MAX_LENGTH}개까지 선택할 수 있어요</Toast.Text>
          </>
        ),
      });
```

위 코드에서 MAX_LENGTH의 타입이 number라 에러가 발생하더라구요. JSX를 그리는데 더 적절한 타입인 것 같아 `ReactNode` 타입으로 바꾸었어용

## 🌄 스크린샷

https://github.com/depromeet/na-lab-client/assets/26461307/dc26dc60-3c87-4837-9175-27e0c1ad4381


