### PR TITLE
review - 마지막 질문 대응

### DIFF
--- a/src/features/review/BottomNavigation.tsx
+++ b/src/features/review/BottomNavigation.tsx
@@ -1,8 +1,10 @@
 import { type MouseEventHandler } from 'react';
 import { css, type Theme } from '@emotion/react';
+import { m } from 'framer-motion';
 
 import Button from '~/components/button/Button';
 import { ArrowCircleButton } from '~/components/button/CircleButton';
+import { defaultFadeInVariants } from '~/constants/motions';
 
 import { type IsLastQuestion } from './steps/type';
 import { fixedBottomCss } from './style';
@@ -23,7 +25,7 @@ const BottomNavigation = ({
 }: Props) => {
   return (
     <>
-      <div css={wrapperCss}>
+      <m.div css={wrapperCss} variants={defaultFadeInVariants} initial="initial" animate="animate" exit="exit">
         <ArrowCircleButton onClick={onBackClick} disabled={isBackDisabled} />
         <Button
           onClick={onNextClick}
@@ -33,7 +35,7 @@ const BottomNavigation = ({
         >
           {isLastQuestion ? '피드백 제출하기' : '다음'}
         </Button>
-      </div>
+      </m.div>
       <div css={wrapperRemainerCss} />
     </>
   );

--- a/src/features/review/BottomNavigation.tsx
+++ b/src/features/review/BottomNavigation.tsx
@@ -4,22 +4,34 @@ import { css, type Theme } from '@emotion/react';
 import Button from '~/components/button/Button';
 import { ArrowCircleButton } from '~/components/button/CircleButton';
 
+import { type IsLastQuestion } from './steps/type';
 import { fixedBottomCss } from './style';
 
-interface Props {
+interface Props extends IsLastQuestion {
   onBackClick?: MouseEventHandler<HTMLButtonElement>;
   isBackDisabled?: boolean;
   onNextClick?: MouseEventHandler<HTMLButtonElement>;
   isNextDisabled?: boolean;
 }
 
-const BottomNavigation = ({ onBackClick, isBackDisabled, onNextClick, isNextDisabled }: Props) => {
+const BottomNavigation = ({
+  onBackClick,
+  isBackDisabled,
+  onNextClick,
+  isNextDisabled,
+  isLastQuestion = false,
+}: Props) => {
   return (
     <>
       <div css={wrapperCss}>
         <ArrowCircleButton onClick={onBackClick} disabled={isBackDisabled} />
-        <Button onClick={onNextClick} disabled={isNextDisabled} css={buttonCss}>
-          다음
+        <Button
+          onClick={onNextClick}
+          disabled={isNextDisabled}
+          css={buttonCss}
+          color={isLastQuestion ? 'blue' : 'navy'}
+        >
+          {isLastQuestion ? '피드백 제출하기' : '다음'}
         </Button>
       </div>
       <div css={wrapperRemainerCss} />
@@ -45,7 +57,7 @@ const wrapperCss = (theme: Theme) => css`
 `;
 
 const buttonCss = css`
-  padding: 15.5px 68px;
+  width: 168px;
 `;
 
 const wrapperRemainerCss = css`

--- a/src/features/review/chat/ChatInputBottom.tsx
+++ b/src/features/review/chat/ChatInputBottom.tsx
@@ -11,7 +11,7 @@ import { m, type TargetAndTransition } from 'framer-motion';
 
 import { ArrowCircleButton } from '~/components/button/CircleButton';
 import SendIcon from '~/components/icons/SendIcon';
-import { defaultEasing } from '~/constants/motions';
+import { defaultEasing, defaultFadeInVariants } from '~/constants/motions';
 import useInput from '~/hooks/common/useInput';
 import { BODY_1 } from '~/styles/typo';
 
@@ -68,7 +68,14 @@ const ChatInputBottom = ({ onBackClick, isBackDisabled, onTextSubmit, onFocus }:
   };
 
   return (
-    <form css={wrapperCss} onSubmit={onSubmit}>
+    <m.form
+      css={wrapperCss}
+      onSubmit={onSubmit}
+      variants={defaultFadeInVariants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+    >
       <m.div animate={backButtonTransition(isInputWide)}>
         <ArrowCircleButton onClick={onBackClick} disabled={isBackDisabled} type="button" />
       </m.div>
@@ -86,7 +93,7 @@ const ChatInputBottom = ({ onBackClick, isBackDisabled, onTextSubmit, onFocus }:
       <button type="submit" disabled={!Boolean(text)} css={buttonCss}>
         <SendIcon />
       </button>
-    </form>
+    </m.form>
   );
 };
 

--- a/src/features/review/chat/SubmitButton.tsx
+++ b/src/features/review/chat/SubmitButton.tsx
@@ -31,12 +31,12 @@ const buttonCss = (theme: Theme) => css`
   ${HEAD_3_SEMIBOLD};
 
   position: fixed;
-  right: 16px;
   bottom: 72px;
 
   display: flex;
   gap: 8px;
   align-items: center;
+  align-self: flex-end;
   justify-content: center;
 
   padding: 8px 16px;

--- a/src/features/review/steps/ChoiceQuestion.tsx
+++ b/src/features/review/steps/ChoiceQuestion.tsx
@@ -1,4 +1,7 @@
 import { css } from '@emotion/react';
+import { m } from 'framer-motion';
+
+import { defaultFadeInVariants } from '~/constants/motions';
 
 import BottomNavigation from '../BottomNavigation';
 import QuestionHeader from '../QuestionHeader';
@@ -22,7 +25,7 @@ const ChoiceQuestion = ({ prev, next, title, max_selectable_count, choices, isLa
   return (
     <>
       <QuestionHeader title={title} subTitle="예진님이 직접 입력한 질문이에요." />
-      <section css={sectionCss}>
+      <m.section css={sectionCss} variants={defaultFadeInVariants} initial="initial" animate="animate" exit="exit">
         <MaxSelectableSmall max={max_selectable_count} />
 
         <div css={choiceWrapperCss}>
@@ -30,7 +33,7 @@ const ChoiceQuestion = ({ prev, next, title, max_selectable_count, choices, isLa
             <Checkbox key={choice.choice_id}>{choice.content}</Checkbox>
           ))}
         </div>
-      </section>
+      </m.section>
       <BottomNavigation onBackClick={prev} onNextClick={next} isLastQuestion={isLastQuestion} />
     </>
   );

--- a/src/features/review/steps/ChoiceQuestion.tsx
+++ b/src/features/review/steps/ChoiceQuestion.tsx
@@ -4,7 +4,7 @@ import BottomNavigation from '../BottomNavigation';
 import QuestionHeader from '../QuestionHeader';
 import Checkbox from './choice/Checkbox';
 import MaxSelectableSmall from './choice/MaxSelectableSmall';
-import { type StepProps } from './type';
+import { type IsLastQuestion, type StepProps } from './type';
 
 // TODO: API 이후 hooks/api 로 이관
 interface Choice {
@@ -12,13 +12,13 @@ interface Choice {
   content: string;
 }
 
-interface Props extends StepProps {
+interface Props extends StepProps, IsLastQuestion {
   title: string;
   choices: Choice[];
   max_selectable_count: number;
 }
 
-const ChoiceQuestion = ({ prev, next, title, max_selectable_count, choices }: Props) => {
+const ChoiceQuestion = ({ prev, next, title, max_selectable_count, choices, isLastQuestion = false }: Props) => {
   return (
     <>
       <QuestionHeader title={title} subTitle="예진님이 직접 입력한 질문이에요." />
@@ -31,7 +31,7 @@ const ChoiceQuestion = ({ prev, next, title, max_selectable_count, choices }: Pr
           ))}
         </div>
       </section>
-      <BottomNavigation onBackClick={prev} onNextClick={next} />
+      <BottomNavigation onBackClick={prev} onNextClick={next} isLastQuestion={isLastQuestion} />
     </>
   );
 };

--- a/src/features/review/steps/ShortQuestion.tsx
+++ b/src/features/review/steps/ShortQuestion.tsx
@@ -8,7 +8,7 @@ import MessageContainer from '../chat/MessageContainer';
 import SubmitButton from '../chat/SubmitButton';
 import { type MessageType } from '../chat/type';
 import QuestionHeader from '../QuestionHeader';
-import { type StepProps } from './type';
+import { type IsLastQuestion, type StepProps } from './type';
 
 interface OtherMessage {
   /**
@@ -18,7 +18,7 @@ interface OtherMessage {
   text: string;
 }
 
-interface Props extends StepProps {
+interface Props extends StepProps, IsLastQuestion {
   headerTitle: ComponentProps<typeof QuestionHeader>['title'];
   setReplies: Dispatch<SetStateAction<string[]>>;
   /**
@@ -31,7 +31,15 @@ interface Props extends StepProps {
   afterUserMessages?: OtherMessage[];
 }
 
-const ShortQuestion = ({ prev, next, headerTitle, setReplies, startMessages, afterUserMessages }: Props) => {
+const ShortQuestion = ({
+  prev,
+  next,
+  headerTitle,
+  setReplies,
+  startMessages,
+  afterUserMessages,
+  isLastQuestion = false,
+}: Props) => {
   const { messages, setMessage, onTextSubmit } = useMessage(setReplies);
   useOtherMessage({ messages, setMessage, startMessages, afterUserMessages });
   const { isAbleToSubmit } = useAbleToSubmit({ messages, startMessages, afterUserMessages });
@@ -41,7 +49,7 @@ const ShortQuestion = ({ prev, next, headerTitle, setReplies, startMessages, aft
       <QuestionHeader title={headerTitle} />
       <MessageContainer messages={messages} />
 
-      {isAbleToSubmit && <SubmitButton onClick={next}>답변 완료</SubmitButton>}
+      {isAbleToSubmit && <SubmitButton onClick={next}>{isLastQuestion ? '피드백 제출하기' : '답변 완료'}</SubmitButton>}
 
       <ChatInputBottom onTextSubmit={onTextSubmit} onBackClick={prev} />
     </>

--- a/src/features/review/steps/ShortQuestion.tsx
+++ b/src/features/review/steps/ShortQuestion.tsx
@@ -48,14 +48,17 @@ const ShortQuestion = ({
   const { isAbleToSubmit } = useAbleToSubmit({ messages, startMessages, afterUserMessages });
 
   return (
-    <m.section css={sectionCss} variants={defaultFadeInVariants} initial="initial" animate="animate" exit="exit">
+    <>
       <QuestionHeader title={headerTitle} />
-      <MessageContainer messages={messages} />
+      <m.section css={sectionCss} variants={defaultFadeInVariants} initial="initial" animate="animate" exit="exit">
+        <MessageContainer messages={messages} />
 
-      {isAbleToSubmit && <SubmitButton onClick={next}>{isLastQuestion ? '피드백 제출하기' : '답변 완료'}</SubmitButton>}
-
+        {isAbleToSubmit && (
+          <SubmitButton onClick={next}>{isLastQuestion ? '피드백 제출하기' : '답변 완료'}</SubmitButton>
+        )}
+      </m.section>
       <ChatInputBottom onTextSubmit={onTextSubmit} onBackClick={prev} />
-    </m.section>
+    </>
   );
 };
 

--- a/src/features/review/steps/ShortQuestion.tsx
+++ b/src/features/review/steps/ShortQuestion.tsx
@@ -1,5 +1,8 @@
 import { type ComponentProps, type Dispatch, type SetStateAction, useRef, useState } from 'react';
+import { css } from '@emotion/react';
+import { m } from 'framer-motion';
 
+import { defaultFadeInVariants } from '~/constants/motions';
 import useDidMount from '~/hooks/lifeCycle/useDidMount';
 import useDidUpdate from '~/hooks/lifeCycle/useDidUpdate';
 
@@ -45,18 +48,25 @@ const ShortQuestion = ({
   const { isAbleToSubmit } = useAbleToSubmit({ messages, startMessages, afterUserMessages });
 
   return (
-    <>
+    <m.section css={sectionCss} variants={defaultFadeInVariants} initial="initial" animate="animate" exit="exit">
       <QuestionHeader title={headerTitle} />
       <MessageContainer messages={messages} />
 
       {isAbleToSubmit && <SubmitButton onClick={next}>{isLastQuestion ? '피드백 제출하기' : '답변 완료'}</SubmitButton>}
 
       <ChatInputBottom onTextSubmit={onTextSubmit} onBackClick={prev} />
-    </>
+    </m.section>
   );
 };
 
 export default ShortQuestion;
+
+const sectionCss = css`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+`;
 
 const useMessage = (setReplies: Props['setReplies']) => {
   const [messages, setMessage] = useState<MessageType[]>([]);

--- a/src/features/review/steps/type.ts
+++ b/src/features/review/steps/type.ts
@@ -4,5 +4,5 @@ export interface StepProps {
 }
 
 export interface IsLastQuestion {
-  isLastQuestion: boolean;
+  isLastQuestion?: boolean;
 }

--- a/src/features/review/steps/type.ts
+++ b/src/features/review/steps/type.ts
@@ -2,3 +2,7 @@ export interface StepProps {
   next?: () => void;
   prev?: () => void;
 }
+
+export interface IsLastQuestion {
+  isLastQuestion: boolean;
+}


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

- close #184 

## 🎉 변경 사항

- 주관식, 객관식 질문 컴포넌트에 옵셔널인 `isLastQuestion` 인터페이스를 추가해, 마지막 질문일 때를 대응했어요
  - 객관식의 경우 `review/BottomNavigation`의 변경이 필요해 동일한 인터페이스를 확장하도록 했어요

- 주관식, 객관식 질문 컴포넌트에 간단한 페이드 애니메이션을 적용했어요
  - 이때 사용하는 `review/BottomNavigation`와 `ChatInputBottom`에도 적용했어요

- fixed인 주관식 질문의 submit 버튼의 위치를 수정했어요


## 🌄 스크린샷

![스크린샷 2023-05-31 오전 12 56 18](https://github.com/depromeet/na-lab-client/assets/26461307/f13e571d-4c6a-49ff-9423-ebc73504555c)

<img width="380" alt="스크린샷 2023-05-31 오후 10 48 13" src="https://github.com/depromeet/na-lab-client/assets/26461307/8aeccf16-2f05-4c86-a71d-46da2c0170ef">


## 📚 참고
