### PR TITLE
review - `StepStatus` 적용

### DIFF
--- a/src/features/review/StepStatus.stories.tsx
+++ b/src/features/review/StepStatus.stories.tsx
@@ -17,7 +17,7 @@ export const Default = ({ stepLength = 3 }) => {
 
   return (
     <>
-      <StepStatus currentStep={currentStep} stepLength={stepLength} />
+      <StepStatus currentStep={currentStep} stepLength={stepLength} notContainSteps={[]} />
 
       <div style={{ marginTop: '200px', display: 'flex' }}>
         <ArrowCircleButton onClick={prev} />

--- a/src/features/review/StepStatus.tsx
+++ b/src/features/review/StepStatus.tsx
@@ -3,23 +3,37 @@ import { css, type Theme, useTheme } from '@emotion/react';
 import { BODY_2_BOLD } from '~/styles/typo';
 
 interface Props {
+  /**
+   * @description 현재 진행중인 스텝
+   */
   currentStep: number;
+  /**
+   * @description 제외할 스텝이 포함된 총 스텝의 길이
+   */
   stepLength: number;
+  /**
+   * @description 제외할 스텝의 index
+   */
+  notContainSteps: number[];
 }
 
-const StepStatus = ({ currentStep, stepLength }: Props) => {
+const StepStatus = ({ currentStep, stepLength, notContainSteps }: Props) => {
   const theme = useTheme();
 
-  const percentage = (currentStep / stepLength) * 100;
+  const { percentage, calculatedCurrentStep, calculatedLength, isCurrentDisabled } = useStepStatus({
+    currentStep,
+    stepLength,
+    notContainSteps,
+  });
 
   return (
-    <div css={wrapperCss}>
+    <div css={wrapperCss(theme, isCurrentDisabled)}>
       <div css={stepBackgroundCss}>
         <div css={stepBarCss(theme, percentage)} />
       </div>
 
       <span css={statusCss}>
-        {currentStep}/{stepLength}
+        {calculatedCurrentStep}/{calculatedLength}
       </span>
     </div>
   );
@@ -27,8 +41,20 @@ const StepStatus = ({ currentStep, stepLength }: Props) => {
 
 export default StepStatus;
 
-const wrapperCss = (theme: Theme) => css`
+const useStepStatus = ({ currentStep, stepLength, notContainSteps }: Props) => {
+  const calculatedCurrentStep = currentStep - notContainSteps.filter((step) => step < currentStep).length + 1;
+  const calculatedLength = stepLength - notContainSteps.length;
+
+  const percentage = (calculatedCurrentStep / calculatedLength) * 100;
+
+  const isCurrentDisabled = notContainSteps.includes(currentStep);
+
+  return { percentage, calculatedCurrentStep, calculatedLength, isCurrentDisabled };
+};
+
+const wrapperCss = (theme: Theme, isCurrentDisabled: boolean) => css`
   position: fixed;
+  z-index: ${theme.zIndex.fixed};
   top: 0;
   left: 50%;
   transform: translateX(-50%);
@@ -36,6 +62,8 @@ const wrapperCss = (theme: Theme) => css`
   width: 100%;
   max-width: ${theme.size.maxWidth};
   margin: 0 auto;
+
+  opacity: ${isCurrentDisabled ? 0 : 1};
 `;
 
 const stepBackgroundCss = (theme: Theme) => css`

--- a/src/features/review/StepStatus.tsx
+++ b/src/features/review/StepStatus.tsx
@@ -64,6 +64,8 @@ const wrapperCss = (theme: Theme, isCurrentDisabled: boolean) => css`
   margin: 0 auto;
 
   opacity: ${isCurrentDisabled ? 0 : 1};
+
+  transition: opacity 0.3s ${theme.transition.defaultEasing};
 `;
 
 const stepBackgroundCss = (theme: Theme) => css`

--- a/src/features/review/steps/Intro.tsx
+++ b/src/features/review/steps/Intro.tsx
@@ -42,7 +42,9 @@ export default Intro;
 
 const sectionCss = (theme: Theme) => css`
   position: relative;
+  z-index: ${theme.zIndex.aboveFixed};
   width: 100%;
+  background-color: ${theme.colors.white};
 
   & strong {
     font-weight: bold;

--- a/src/features/review/steps/Intro.tsx
+++ b/src/features/review/steps/Intro.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence, m } from 'framer-motion';
 
 import CTAButton from '~/components/button/CTAButton';
 import StaggerWrapper from '~/components/stagger/StaggerWrapper';
-import { defaultEasing } from '~/constants/motions';
+import { defaultEasing, defaultFadeInVariants } from '~/constants/motions';
 import useBoolean from '~/hooks/common/useBoolean';
 import useStep from '~/hooks/step/useStep';
 
@@ -17,7 +17,7 @@ const Intro = ({ next }: StepProps) => {
 
   // TODO: section에 인터랙션 적용
   return (
-    <section css={sectionCss}>
+    <m.section css={sectionCss} variants={defaultFadeInVariants} initial="initial" animate="animate" exit="exit">
       <article css={articleCss}>
         <AnimatePresence mode="wait">
           {currentStep === 1 && <Paragraph1 key="1" />}
@@ -28,13 +28,13 @@ const Intro = ({ next }: StepProps) => {
       </article>
 
       {isCTAButtonVisible && (
-        <m.div css={fixedBottomCss} variants={CTAVariants} initial="initial" animate="animate" exit="exit">
+        <m.div css={fixedBottomCss} variants={CTAVariants}>
           <CTAButton color="blue" onClick={next}>
             시작하기
           </CTAButton>
         </m.div>
       )}
-    </section>
+    </m.section>
   );
 };
 

--- a/src/features/review/steps/Last.tsx
+++ b/src/features/review/steps/Last.tsx
@@ -62,10 +62,14 @@ const Last = ({ onSubmit }: Props) => {
 
 export default Last;
 
-const sectionCss = css`
+const sectionCss = (theme: Theme) => css`
+  z-index: ${theme.zIndex.aboveFixed};
+
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  background-color: ${theme.colors.white};
 `;
 
 const headerCss = css`

--- a/src/features/review/steps/QuestionIntro.tsx
+++ b/src/features/review/steps/QuestionIntro.tsx
@@ -39,8 +39,12 @@ export default QuestionIntro;
 
 const sectionCss = (theme: Theme) => css`
   position: relative;
+  z-index: ${theme.zIndex.aboveFixed};
+
   width: 100%;
   height: 100%;
+
+  background-color: ${theme.colors.white};
 
   & strong {
     font-weight: bold;

--- a/src/hooks/step/useInjectedElementStep.ts
+++ b/src/hooks/step/useInjectedElementStep.ts
@@ -13,6 +13,7 @@ const useInjectedElementStep = ({ initial = 0, elements }: Props) => {
 
   return {
     currentElement: cloneElement(elements[currentStep], { next, prev }),
+    currentStep,
     prev,
     next,
   };

--- a/src/pages/review/[token].page.tsx
+++ b/src/pages/review/[token].page.tsx
@@ -8,6 +8,7 @@ import ChoiceQuestion from '~/features/review/steps/ChoiceQuestion';
 import Intro from '~/features/review/steps/Intro';
 import Last from '~/features/review/steps/Last';
 import { type Position as PositionType } from '~/features/review/steps/type';
+import StepStatus from '~/features/review/StepStatus';
 import useInjectedElementStep from '~/hooks/step/useInjectedElementStep';
 
 const Cowork = dynamic(() => import('~/features/review/steps/Cowork'), { ssr: false });
@@ -33,11 +34,11 @@ const ReviewPage = () => {
   const { selectedSoftskills, setSelectedSoftskills } = useSoftskills();
   const { setStrength } = useStrength();
 
-  const { currentElement } = useInjectedElementStep({
+  const { currentElement, currentStep } = useInjectedElementStep({
     elements: [
-      <Position key="position" position={position} setPosition={setPosition} />,
       <Intro key="intro" />,
       <Cowork key="cowork" isCoworked={isCoworked} setIsCoworked={setIsCoworked} />,
+      <Position key="position" position={position} setPosition={setPosition} />,
       <QuestionIntro key="question-intro" />,
       <Softskill
         key="softskill"
@@ -71,9 +72,13 @@ const ReviewPage = () => {
   });
 
   return (
-    <main css={mainCss}>
-      <AnimatePresence mode="wait">{currentElement}</AnimatePresence>
-    </main>
+    <>
+      {/* TODO: API res에 따라 동적으로 생성되는 elements의 길이 주입 필요 */}
+      <StepStatus currentStep={currentStep} stepLength={9} notContainSteps={[0, 3, 8]} />
+      <main css={mainCss}>
+        <AnimatePresence mode="wait">{currentElement}</AnimatePresence>
+      </main>
+    </>
   );
 };
 


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

- close #172 

## 🎉 변경 사항

- 리뷰어 페이지에 `StepStatus`를 적용했어요

- `StepStatus`보다 위에 있어야 하는 요소들이 존재해 `z-index` 값만 조정하면 될 줄 알았는데,
디자인 상 `StepStatus`가 화면 전체를 사용해, 양옆이 보이는 이슈가 있었어요
  - 그래서 비활성화되는 index를 주입받아 opacity를 조절하도록 했어요
  - 비활성화되는 index는 `[0 (인트로), 3 (질문 인트로), {마지막 인덱스} ]`가 돼요

- 관련해서 `StepStatus` 로직을 변경했어요

## 🌄 스크린샷



https://github.com/depromeet/na-lab-client/assets/26461307/4b9a1e3b-e5f2-440e-b29e-33fdfa3cc4c3


