### PR TITLE
axios 인스턴스 수정 및 `useGetSurveyById` 개발

### DIFF
--- a/src/hooks/api/surveys/useGetSurveyById.ts
+++ b/src/hooks/api/surveys/useGetSurveyById.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { get } from '~/libs/api';
+
+const useGetSurveyById = (id: string) => {
+  return useQuery({ queryKey: ['survey', id], queryFn: () => get(`/surveys/${id}`) });
+};
+
+export default useGetSurveyById;

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -6,12 +6,11 @@ import { errorMessage } from '~/exceptions/messages';
 import { type ApiErrorScheme } from '~/exceptions/type';
 import { isProd } from '~/utils/common';
 
-const DEVELOPMENT_API_URL = ' https://testapi.nalab.me';
-const PRODUCTION_API_URL = 'https://api.nalab.me';
+const DEVELOPMENT_API_URL = ' https://api.nalab.me/mock';
+const PRODUCTION_API_URL = 'https://api.nalab.me/v1';
 
 const instance = axios.create({
   baseURL: isProd(process.env.NODE_ENV) ? PRODUCTION_API_URL : DEVELOPMENT_API_URL,
-  withCredentials: true,
   timeout: 15000,
 });
 


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

- axios 인스턴스 수정
- 질문폼 조회를 담당하는 hook 개발

## 🎉 변경 사항

- axios 인스턴스의 개발 환경 `baseUrl`을 `mock api`로 맞춰뒀어요
  - 추후 개발 api 이중화 혹은 프로덕션 api 안정화 시 수정이 필요해요

- `withCredentials`를 해제했어요
  - allow origin 헤더를 전체로 설정하고 있는데, 관련해서 CORS가 발생하며 쿠키를 사용하지 않아 필요없다고 판단했어요
  - https://developer.mozilla.org/ko/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials?utm_source=devtools&utm_medium=firefox-cors-errors&utm_campaign=default

- `useGetSurveyById` 훅을 만들었어요
  - 저는 api 관련 훅들을 이렇게 만들어 놓곤 했는데, 다른 선호하시는 방법이 있으신지 궁금해요

### 사용 방법

```tsx
const { data } = useGetSurveyById('1');
```





## 📚 참고

![슬랙 스레드](https://depromeet13th.slack.com/archives/C051YE0BLGG/p1685929276651379)