### PR TITLE
추가 질문 전역상태로 변경

### DIFF
--- a/src/features/survey/AdditionalQuestionList.tsx
+++ b/src/features/survey/AdditionalQuestionList.tsx
@@ -1,6 +1,5 @@
-import { type Dispatch } from 'react';
 import { Reorder } from 'framer-motion';
-import { type SetStateAction } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 
 import useToast from '~/components/toast/useToast';
 import AddMyQuestion from '~/features/survey/addSurveyForm/AddMyQuestion';
@@ -8,18 +7,24 @@ import QuestionWithDnd from '~/features/survey/questionList/QuestionWithDnd';
 import SurveyFormBottomSheet from '~/features/survey/SurveyFormBottomSheet';
 import { type QuestionItem } from '~/features/survey/types';
 import useBoolean from '~/hooks/common/useBoolean';
+import {
+  addSurveyCustomQuestionAtom,
+  deleteSurveyCustomQuestionAtom,
+  getSurveyCustomQuestionsAtom,
+  reorderSurveyCustomQuestionsAtom,
+} from '~/store/surveyCustomQuestions';
 
-interface Props {
-  customItems: QuestionItem[];
-  setCustomsItems: Dispatch<SetStateAction<QuestionItem[]>>;
-}
+const AdditionalQuestionList = () => {
+  const customItems = useAtomValue(getSurveyCustomQuestionsAtom);
+  const addCustomQuestion = useSetAtom(addSurveyCustomQuestionAtom);
+  const deleteCustomQuestion = useSetAtom(deleteSurveyCustomQuestionAtom);
+  const reorderCustomQuestions = useSetAtom(reorderSurveyCustomQuestionsAtom);
 
-const AdditionalQuestionList = ({ customItems, setCustomsItems }: Props) => {
   const [isShowing, toggleShowing] = useBoolean(false);
   const { fireToast } = useToast();
 
   const addNewQuestion = (question: QuestionItem) => {
-    setCustomsItems((prev) => [...prev, question]);
+    addCustomQuestion(question);
     toggleShowing();
   };
 
@@ -33,13 +38,13 @@ const AdditionalQuestionList = ({ customItems, setCustomsItems }: Props) => {
     toggleShowing();
   };
 
-  const onDeleteCustomQuestion = (id: string) => {
-    setCustomsItems((prev) => prev.filter((item) => item.title !== id));
+  const onDeleteCustomQuestion = (questionTitle: string) => {
+    deleteCustomQuestion(questionTitle);
   };
 
   return (
     <>
-      <Reorder.Group data-testid="dnd-component" as="ul" values={customItems} onReorder={setCustomsItems}>
+      <Reorder.Group data-testid="dnd-component" as="ul" values={customItems} onReorder={reorderCustomQuestions}>
         {customItems.map((item) => (
           <QuestionWithDnd item={item} key={item.title} onDelete={onDeleteCustomQuestion} />
         ))}

--- a/src/features/survey/CreateSurvey.tsx
+++ b/src/features/survey/CreateSurvey.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { useAtomValue } from 'jotai';
 
 import CTAButton from '~/components/button/CTAButton';
 import AddQuestionList from '~/features/survey/AdditionalQuestionList';
@@ -10,14 +11,16 @@ import { type QuestionItem, type QuestionRequest } from '~/features/survey/types
 import useBoolean from '~/hooks/common/useBoolean';
 import useInternalRouter from '~/hooks/router/useInternalRouter';
 import useLocalStorage from '~/hooks/storage/useLocalStorage';
+import { getSurveyCustomQuestionsAtom } from '~/store/surveyCustomQuestions';
 
 const CreateSurvey = () => {
   const router = useInternalRouter();
 
   const [isDialogShowing, toggleDialogShowing] = useBoolean(false);
 
-  const [customItems, setCustomsItems] = useLocalStorage<QuestionItem[]>('customQuestions', []);
   const [_, setCreateSurveyRequest] = useLocalStorage<QuestionRequest[]>('createSurveyRequest', []);
+
+  const customItems = useAtomValue(getSurveyCustomQuestionsAtom);
 
   const onCreateSurvey = () => {
     const data = getCreateSurveyRequestData(customItems);
@@ -35,7 +38,7 @@ const CreateSurvey = () => {
 
       <section css={sectionCss}>
         <h1>추가 질문</h1>
-        <AddQuestionList customItems={customItems} setCustomsItems={setCustomsItems} />
+        <AddQuestionList />
       </section>
 
       <section css={[fixedBottomCss]}>

--- a/src/features/survey/questionList/QuestionWithDnd.tsx
+++ b/src/features/survey/questionList/QuestionWithDnd.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/react';
 import { animate, AnimatePresence, m, Reorder, useDragControls, useMotionValue } from 'framer-motion';
 import { useAtomValue } from 'jotai';
@@ -22,10 +21,9 @@ interface Props {
   onDelete: (title: string) => void;
 }
 
-function QuestionWithDnd({ item, onDelete }: Props) {
-  // isDeleteMode 전역으로 변경하기
-
+const QuestionWithDnd = ({ item, onDelete }: Props) => {
   const isDeleteMode = useAtomValue(surveyDeleteModeAtom);
+
   const dragControls = useDragControls();
 
   const y = useMotionValue(0);
@@ -63,11 +61,13 @@ function QuestionWithDnd({ item, onDelete }: Props) {
           </m.div>
         )}
       </AnimatePresence>
+
       <Question item={item} />
+
       {!isDeleteMode && <MenuIcon onPointerDown={(e) => dragControls.start(e)} css={menuIconCss} />}
     </Reorder.Item>
   );
-}
+};
 
 export default QuestionWithDnd;
 

--- a/src/pages/survey/create.page.tsx
+++ b/src/pages/survey/create.page.tsx
@@ -11,10 +11,10 @@ import { BODY_1 } from '~/styles/typo';
 
 const CreateSurveyPage = () => {
   const router = useInternalRouter();
-  const [isDialogOpen, _, onDialogOpen, onDialogClose] = useBoolean(false);
-  // const [isDeleteMode, toggleIsDeleteMode] = useBoolean(false);
 
   const [isDeleteMode, setIsDeleteMode] = useAtom(surveyDeleteModeAtom);
+
+  const [isDialogOpen, _, onDialogOpen, onDialogClose] = useBoolean(false);
 
   const onStop = () => {
     onDialogClose();

--- a/src/store/surveyCustomQuestions.ts
+++ b/src/store/surveyCustomQuestions.ts
@@ -1,0 +1,25 @@
+import { atom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
+
+import { type QuestionItem } from '~/features/survey/types';
+
+const surveyCustomQuestionsAtom = atomWithStorage<QuestionItem[]>('customQuestions', []);
+
+export const getSurveyCustomQuestionsAtom = atom((get) => get(surveyCustomQuestionsAtom));
+
+export const reorderSurveyCustomQuestionsAtom = atom(null, (get, set, update: QuestionItem[]) => {
+  set(surveyCustomQuestionsAtom, update);
+});
+
+export const addSurveyCustomQuestionAtom = atom(null, (get, set, question: QuestionItem) => {
+  const prev = get(surveyCustomQuestionsAtom);
+  set(surveyCustomQuestionsAtom, [...prev, question]);
+});
+
+export const deleteSurveyCustomQuestionAtom = atom(null, (get, set, questionTitle: string) => {
+  const prev = get(surveyCustomQuestionsAtom);
+  set(
+    surveyCustomQuestionsAtom,
+    prev.filter((item) => item.title !== questionTitle),
+  );
+});


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
추가 질문 전역상태로 변경
## 🎉 변경 사항
- `surveyCustomQuestionsAtom` 전역상태 추가  - 추가 질문 리스트
### 🙏 여기는 꼭 봐주세요!
- `surveyCustomQuestionsAtom` atom을 내보내지 않고, getter, setter atom을 만들어 내보내는 방식을 사용해,
`surveyCustomQuestionsAtom`을 private하게 관리하도록 하였어요. 
 
## 📚 참고
- https://jotai.org/docs/core/atom