### PR TITLE
review - 뒤로가기 시 이전 값 유지

### DIFF
--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,3 +1,4 @@
 export const LOCAL_STORAGE_KEY = {
   accessToken: 'nlac',
+  reviewShortQuestionMessages: 'nlasq',
 } as const;

--- a/src/exceptions/ApiException.ts
+++ b/src/exceptions/ApiException.ts
@@ -4,7 +4,7 @@ class ApiException<ErrorCode = number> extends Error {
   declare code: ErrorCode;
 
   constructor(data: ApiErrorScheme, code: ErrorCode) {
-    super(data['response-message']);
+    super(data['response_messages']);
     this.name = 'ApiException';
     this.code = code;
   }

--- a/src/exceptions/type.ts
+++ b/src/exceptions/type.ts
@@ -1,3 +1,3 @@
 export interface ApiErrorScheme {
-  'response-message': string;
+  response_messages: string;
 }

--- a/src/features/review/StepStatus.stories.tsx
+++ b/src/features/review/StepStatus.stories.tsx
@@ -20,8 +20,8 @@ export const Default = ({ stepLength = 3 }) => {
       <StepStatus currentStep={currentStep} stepLength={stepLength} notContainSteps={[]} />
 
       <div style={{ marginTop: '200px', display: 'flex' }}>
-        <ArrowCircleButton onClick={prev} />
-        <ArrowCircleButton direction="right" onClick={next} />
+        <ArrowCircleButton onClick={() => prev()} />
+        <ArrowCircleButton direction="right" onClick={() => next()} />
       </div>
     </>
   );

--- a/src/features/review/steps/ChoiceQuestion.tsx
+++ b/src/features/review/steps/ChoiceQuestion.tsx
@@ -51,7 +51,7 @@ const ChoiceQuestion = ({
           ))}
         </div>
       </m.section>
-      <BottomNavigation onBackClick={prev} onNextClick={next} isLastQuestion={isLastQuestion} />
+      <BottomNavigation onBackClick={() => prev?.()} onNextClick={() => next?.()} isLastQuestion={isLastQuestion} />
     </>
   );
 };

--- a/src/features/review/steps/ChoiceQuestion.tsx
+++ b/src/features/review/steps/ChoiceQuestion.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEventHandler } from 'react';
+import { type ChangeEventHandler, type ComponentProps } from 'react';
 import { css } from '@emotion/react';
 import { m } from 'framer-motion';
 
@@ -13,7 +13,7 @@ import { type IsLastQuestion, type StepProps } from './type';
 
 interface Props extends StepProps, IsLastQuestion {
   nickname: string;
-  title: string;
+  title: ComponentProps<typeof QuestionHeader>['title'];
   selectedChoicesId: number[];
   choices: Choice[];
   max_selectable_count: number;

--- a/src/features/review/steps/ChoiceQuestion.tsx
+++ b/src/features/review/steps/ChoiceQuestion.tsx
@@ -1,10 +1,9 @@
-import { type ChangeEventHandler, useState } from 'react';
+import { type ChangeEventHandler } from 'react';
 import { css } from '@emotion/react';
 import { m } from 'framer-motion';
 
 import { defaultFadeInVariants } from '~/constants/motions';
 import { type Choice } from '~/hooks/api/surveys/useGetSurveyById';
-import useDidUpdate from '~/hooks/lifeCycle/useDidUpdate';
 
 import BottomNavigation from '../BottomNavigation';
 import QuestionHeader from '../QuestionHeader';
@@ -15,6 +14,7 @@ import { type IsLastQuestion, type StepProps } from './type';
 interface Props extends StepProps, IsLastQuestion {
   nickname: string;
   title: string;
+  selectedChoicesId: number[];
   choices: Choice[];
   max_selectable_count: number;
   setChoices: (setStateAction: (prevState: number[]) => number[]) => void;
@@ -26,11 +26,12 @@ const ChoiceQuestion = ({
   next,
   title,
   max_selectable_count,
+  selectedChoicesId,
   choices,
   setChoices,
   isLastQuestion = false,
 }: Props) => {
-  const { innerChoices, onChange } = useChoices({ max_selectable_count, setChoices });
+  const { onChange } = useChoices({ max_selectable_count, selectedChoicesId, setChoices });
 
   return (
     <>
@@ -44,7 +45,7 @@ const ChoiceQuestion = ({
               key={choice_id}
               value={choice_id}
               onChange={onChange}
-              checked={innerChoices.some((checkedChoiceId) => checkedChoiceId === choice_id)}
+              checked={selectedChoicesId.some((checkedChoiceId) => checkedChoiceId === choice_id)}
             >
               {content}
             </Checkbox>
@@ -79,32 +80,26 @@ const choiceWrapperCss = css`
   margin-top: 12px;
 `;
 
-type UseChoicesProps = Pick<Props, 'max_selectable_count' | 'setChoices'>;
+type UseChoicesProps = Pick<Props, 'max_selectable_count' | 'selectedChoicesId' | 'setChoices'>;
 
-const useChoices = ({ max_selectable_count, setChoices }: UseChoicesProps) => {
-  const [innerChoices, setInnerChoices] = useState<number[]>([]);
-
+const useChoices = ({ max_selectable_count, selectedChoicesId, setChoices }: UseChoicesProps) => {
   const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     const choiceId = Number(e.target.value);
 
     if (!e.target.checked) {
-      setInnerChoices((prev) => prev.filter((prevChoiceId) => prevChoiceId !== choiceId));
+      setChoices((prev) => prev.filter((prevChoiceId) => prevChoiceId !== choiceId));
 
       return;
     }
 
-    if (innerChoices.length >= max_selectable_count) {
-      setInnerChoices((prev) => [...prev.slice(1), choiceId]);
+    if (selectedChoicesId.length >= max_selectable_count) {
+      setChoices((prev) => [...prev.slice(1), choiceId]);
 
       return;
     }
 
-    setInnerChoices((prev) => [...prev, choiceId]);
+    setChoices((prev) => [...prev, choiceId]);
   };
 
-  useDidUpdate(() => {
-    setChoices(() => innerChoices);
-  }, [innerChoices]);
-
-  return { innerChoices, onChange };
+  return { onChange };
 };

--- a/src/features/review/steps/Cowork.tsx
+++ b/src/features/review/steps/Cowork.tsx
@@ -21,6 +21,7 @@ interface Props extends StepProps {
 
 const Cowork = ({ prev, next, isCoworked, setIsCoworked }: Props) => {
   const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    console.log('ff');
     setIsCoworked(Boolean(e.target.value));
   };
 
@@ -32,12 +33,24 @@ const Cowork = ({ prev, next, isCoworked, setIsCoworked }: Props) => {
         <div css={outerCircleCss}>
           <m.div css={innerCircleCss(isCoworked)}>
             <label css={[inputLabelCss, yesLabelCss]}>
-              <input type="radio" name={RADIO_NAME} value="yes" onChange={onChange} />
+              <input
+                type="radio"
+                name={RADIO_NAME}
+                value="yes"
+                defaultChecked={Boolean(isCoworked)}
+                onChange={onChange}
+              />
               <span>네, 있어요</span>
             </label>
 
             <label css={[inputLabelCss, noLabelCss]}>
-              <input type="radio" name={RADIO_NAME} value="" onChange={onChange} />
+              <input
+                type="radio"
+                name={RADIO_NAME}
+                value=""
+                defaultChecked={typeof isCoworked === 'boolean' && isCoworked === false}
+                onChange={onChange}
+              />
               <span>없어요</span>
             </label>
           </m.div>

--- a/src/features/review/steps/Cowork.tsx
+++ b/src/features/review/steps/Cowork.tsx
@@ -21,7 +21,6 @@ interface Props extends StepProps {
 
 const Cowork = ({ prev, next, isCoworked, setIsCoworked }: Props) => {
   const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-    console.log('ff');
     setIsCoworked(Boolean(e.target.value));
   };
 
@@ -57,7 +56,12 @@ const Cowork = ({ prev, next, isCoworked, setIsCoworked }: Props) => {
         </div>
       </m.section>
 
-      <BottomNavigation isBackDisabled onBackClick={prev} isNextDisabled={isCoworked === null} onNextClick={next} />
+      <BottomNavigation
+        isBackDisabled
+        onBackClick={() => prev?.()}
+        isNextDisabled={isCoworked === null}
+        onNextClick={() => next?.()}
+      />
     </>
   );
 };

--- a/src/features/review/steps/Intro.tsx
+++ b/src/features/review/steps/Intro.tsx
@@ -41,7 +41,7 @@ const Intro = ({ nickname, next }: Props) => {
 
       {isCTAButtonVisible && (
         <m.div css={fixedBottomCss} variants={CTAVariants}>
-          <CTAButton color="blue" onClick={next}>
+          <CTAButton color="blue" onClick={() => next?.()}>
             시작하기
           </CTAButton>
         </m.div>

--- a/src/features/review/steps/Position.tsx
+++ b/src/features/review/steps/Position.tsx
@@ -76,7 +76,13 @@ const Position = ({ prev, next, position, setPosition }: Props) => {
     <>
       <QuestionHeader title="당신의 포지션을 알려주세요." />
       <m.section css={sectionCss} variants={defaultFadeInVariants} initial="initial" animate="animate" exit="exit">
-        <Flicking align="center" circular plugins={plugins} css={positionWrapperCss}>
+        <Flicking
+          align="center"
+          circular
+          plugins={plugins}
+          css={positionWrapperCss}
+          defaultIndex={positionCards.findIndex((p) => p.value === position)}
+        >
           {/* NOTE: @egjs/flicking 사용으로 인해 div로 한 번 더 감싸줌 */}
           {positionCards.map((eachPosition) => (
             <div key={eachPosition.title}>

--- a/src/features/review/steps/Position.tsx
+++ b/src/features/review/steps/Position.tsx
@@ -100,7 +100,7 @@ const Position = ({ prev, next, position, setPosition }: Props) => {
           ))}
         </Flicking>
       </m.section>
-      <BottomNavigation onBackClick={prev} isNextDisabled={position === null} onNextClick={next} />
+      <BottomNavigation onBackClick={() => prev?.()} isNextDisabled={position === null} onNextClick={() => next?.()} />
     </>
   );
 };

--- a/src/features/review/steps/ShortQuestion.tsx
+++ b/src/features/review/steps/ShortQuestion.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { m } from 'framer-motion';
 
 import { defaultFadeInVariants } from '~/constants/motions';
+import { LOCAL_STORAGE_KEY } from '~/constants/storage';
 import { type DefaultQuestion } from '~/hooks/api/surveys/useGetSurveyById';
 import useDidMount from '~/hooks/lifeCycle/useDidMount';
 import useDidUpdate from '~/hooks/lifeCycle/useDidUpdate';
@@ -78,7 +79,10 @@ const sectionCss = css`
 type UseMessageProps = Pick<Props, 'questionId' | 'setReplies'>;
 
 const useMessage = ({ questionId, setReplies }: UseMessageProps) => {
-  const [messages, setMessage] = useLocalStorage<MessageType[]>(`nlasq ${questionId}`, []);
+  const [messages, setMessage] = useLocalStorage<MessageType[]>(
+    `${LOCAL_STORAGE_KEY.reviewShortQuestionMessages} ${questionId}`,
+    [],
+  );
 
   const onTextSubmit = (text: string) => {
     setReplies((prev) => [...prev, text]);

--- a/src/features/review/steps/ShortQuestion.tsx
+++ b/src/features/review/steps/ShortQuestion.tsx
@@ -51,8 +51,6 @@ const ShortQuestion = ({
   useOtherMessage({ messages, setMessage, startMessages, afterUserMessages });
   const { isAbleToSubmit } = useAbleToSubmit({ messages, startMessages, afterUserMessages });
 
-  console.log(messages);
-
   return (
     <>
       <QuestionHeader title={headerTitle} />

--- a/src/features/review/steps/ShortQuestion.tsx
+++ b/src/features/review/steps/ShortQuestion.tsx
@@ -54,10 +54,10 @@ const ShortQuestion = ({
         <MessageContainer messages={messages} />
 
         {isAbleToSubmit && (
-          <SubmitButton onClick={next}>{isLastQuestion ? '피드백 제출하기' : '답변 완료'}</SubmitButton>
+          <SubmitButton onClick={() => next?.()}>{isLastQuestion ? '피드백 제출하기' : '답변 완료'}</SubmitButton>
         )}
       </m.section>
-      <ChatInputBottom onTextSubmit={onTextSubmit} onBackClick={prev} />
+      <ChatInputBottom onTextSubmit={onTextSubmit} onBackClick={() => prev?.()} />
     </>
   );
 };

--- a/src/features/review/steps/ShortQuestion.tsx
+++ b/src/features/review/steps/ShortQuestion.tsx
@@ -3,8 +3,10 @@ import { css } from '@emotion/react';
 import { m } from 'framer-motion';
 
 import { defaultFadeInVariants } from '~/constants/motions';
+import { type DefaultQuestion } from '~/hooks/api/surveys/useGetSurveyById';
 import useDidMount from '~/hooks/lifeCycle/useDidMount';
 import useDidUpdate from '~/hooks/lifeCycle/useDidUpdate';
+import useLocalStorage from '~/hooks/storage/useLocalStorage';
 
 import ChatInputBottom from '../chat/ChatInputBottom';
 import MessageContainer from '../chat/MessageContainer';
@@ -23,6 +25,7 @@ interface OtherMessage {
 
 interface Props extends StepProps, IsLastQuestion {
   headerTitle: ComponentProps<typeof QuestionHeader>['title'];
+  questionId: DefaultQuestion['question_id'];
   setReplies: (setStateAction: (prevState: string[]) => string[]) => void;
   /**
    * @description 시작할 때 입력될 메세지와 시간
@@ -38,14 +41,17 @@ const ShortQuestion = ({
   prev,
   next,
   headerTitle,
+  questionId,
   setReplies,
   startMessages,
   afterUserMessages,
   isLastQuestion = false,
 }: Props) => {
-  const { messages, setMessage, onTextSubmit } = useMessage(setReplies);
+  const { messages, setMessage, onTextSubmit } = useMessage({ questionId, setReplies });
   useOtherMessage({ messages, setMessage, startMessages, afterUserMessages });
   const { isAbleToSubmit } = useAbleToSubmit({ messages, startMessages, afterUserMessages });
+
+  console.log(messages);
 
   return (
     <>
@@ -71,8 +77,10 @@ const sectionCss = css`
   height: 100%;
 `;
 
-const useMessage = (setReplies: Props['setReplies']) => {
-  const [messages, setMessage] = useState<MessageType[]>([]);
+type UseMessageProps = Pick<Props, 'questionId' | 'setReplies'>;
+
+const useMessage = ({ questionId, setReplies }: UseMessageProps) => {
+  const [messages, setMessage] = useLocalStorage<MessageType[]>(`nlasq ${questionId}`, []);
 
   const onTextSubmit = (text: string) => {
     setReplies((prev) => [...prev, text]);
@@ -92,6 +100,9 @@ interface UseOtherMessageProps {
 const useOtherMessage = ({ messages, setMessage, startMessages, afterUserMessages }: UseOtherMessageProps) => {
   useDidMount(() => {
     const timeouts: NodeJS.Timeout[] = [];
+
+    // NOTE: 이미 발송된 적이 있다면 발송하지 않음
+    if (messages.length > 0) return;
 
     startMessages.forEach(({ timing, text }) => {
       const timeout = setTimeout(() => {
@@ -114,17 +125,20 @@ const useOtherMessage = ({ messages, setMessage, startMessages, afterUserMessage
 
     const timeouts: NodeJS.Timeout[] = [];
 
-    if (messages.length > startMessages.length) {
-      isSetAfterMessage.current = true;
+    // NOTE: 초기 메시지가 아직 발송되지 않았다면
+    if (messages.length <= startMessages.length) return;
+    // NOTE: 발송됐었다면
+    if (messages.length > startMessages.length + afterUserMessages.length) return;
 
-      afterUserMessages.forEach(({ timing, text }) => {
-        const timeout = setTimeout(() => {
-          setMessage((prev) => [...prev, { from: 'other', content: text }]);
-        }, timing);
+    isSetAfterMessage.current = true;
 
-        timeouts.push(timeout);
-      });
-    }
+    afterUserMessages.forEach(({ timing, text }) => {
+      const timeout = setTimeout(() => {
+        setMessage((prev) => [...prev, { from: 'other', content: text }]);
+      }, timing);
+
+      timeouts.push(timeout);
+    });
 
     return () => {
       isSetAfterMessage.current = false;

--- a/src/features/review/steps/ShortQuestion.tsx
+++ b/src/features/review/steps/ShortQuestion.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, type Dispatch, type SetStateAction, useRef, useState } from 'react';
+import { type ComponentProps, type Dispatch, type SetStateAction, useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import { m } from 'framer-motion';
 
@@ -158,7 +158,7 @@ interface UseAbleToSubmitProps {
 const useAbleToSubmit = ({ messages, startMessages, afterUserMessages }: UseAbleToSubmitProps) => {
   const [isAbleToSubmit, setIsAbleToSubmit] = useState(false);
 
-  useDidUpdate(() => {
+  useEffect(() => {
     if (isAbleToSubmit) return;
 
     const allOtherMessageLength = startMessages.length + (afterUserMessages?.length ?? 0);
@@ -169,6 +169,7 @@ const useAbleToSubmit = ({ messages, startMessages, afterUserMessages }: UseAble
     return () => {
       clearTimeout(timeout);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messages]);
 
   return { isAbleToSubmit };

--- a/src/features/review/steps/Softskill.tsx
+++ b/src/features/review/steps/Softskill.tsx
@@ -68,7 +68,11 @@ const Softskill = ({ prev, next, selectedSoftskills, setSelectedSoftskills }: Pr
           />
         ))}
       </section>
-      <BottomNavigation onBackClick={prev} isNextDisabled={!Boolean(selectedSoftskills.length)} onNextClick={next} />
+      <BottomNavigation
+        onBackClick={() => prev?.(2)}
+        isNextDisabled={!Boolean(selectedSoftskills.length)}
+        onNextClick={() => next?.()}
+      />
     </>
   );
 };

--- a/src/features/review/steps/Softskill.tsx
+++ b/src/features/review/steps/Softskill.tsx
@@ -65,6 +65,7 @@ const Softskill = ({ prev, next, selectedSoftskills, setSelectedSoftskills }: Pr
             graphicName={softskill}
             name={softskill.replace('_', ' ')}
             onChange={onChange}
+            checked={selectedSoftskills.includes(softskill)}
           />
         ))}
       </section>

--- a/src/features/review/steps/type.ts
+++ b/src/features/review/steps/type.ts
@@ -1,6 +1,10 @@
+import type useStep from '~/hooks/step/useStep';
+
+type UseStepReturn = ReturnType<typeof useStep>;
+
 export interface StepProps {
-  next?: () => void;
-  prev?: () => void;
+  next?: UseStepReturn['next'];
+  prev?: UseStepReturn['prev'];
 }
 
 export type Position = 'designer' | 'product-manager' | 'programmer' | 'other';

--- a/src/hooks/api/surveys/useGetSurveyById.ts
+++ b/src/hooks/api/surveys/useGetSurveyById.ts
@@ -32,17 +32,17 @@ interface ChoiceQuestion extends DefaultQuestion {
   choices: Choice[];
 }
 
-export interface Request {
+export interface Response {
   survey_id: number;
   question_count: number;
   target: Target;
   question: (ShortQuestion | ChoiceQuestion)[];
 }
 
-const useGetSurveyById = (id: string, option?: UseQueryOptions<Request>) => {
-  return useQuery<Request>({
+const useGetSurveyById = (id: string, option?: UseQueryOptions<Response>) => {
+  return useQuery<Response>({
     queryKey: ['survey', id],
-    queryFn: () => get<Request>(`/surveys/${id}`),
+    queryFn: () => get<Response>(`/surveys/${id}`),
     ...option,
   });
 };

--- a/src/hooks/api/surveys/useGetSurveyById.ts
+++ b/src/hooks/api/surveys/useGetSurveyById.ts
@@ -7,11 +7,17 @@ interface Target {
   nickname: string;
 }
 
-interface ShortQuestion {
-  type: 'short';
+type FormType = 'tendency' | 'choice' | 'strength';
+
+interface DefaultQuestion {
   question_id: number;
   order: number;
   title: string;
+  form_type: FormType;
+}
+
+interface ShortQuestion extends DefaultQuestion {
+  type: 'short';
 }
 
 export interface Choice {
@@ -20,12 +26,9 @@ export interface Choice {
   content: string;
 }
 
-interface ChoiceQuestion {
+interface ChoiceQuestion extends DefaultQuestion {
   type: 'choice';
-  question_id: number;
-  order: number;
   max_selectable_count: number;
-  title: string;
   choices: Choice[];
 }
 

--- a/src/hooks/api/surveys/useGetSurveyById.ts
+++ b/src/hooks/api/surveys/useGetSurveyById.ts
@@ -9,7 +9,7 @@ interface Target {
 
 type FormType = 'tendency' | 'choice' | 'strength';
 
-interface DefaultQuestion {
+export interface DefaultQuestion {
   question_id: number;
   order: number;
   title: string;

--- a/src/hooks/step/useStep.ts
+++ b/src/hooks/step/useStep.ts
@@ -8,15 +8,15 @@ interface Props {
 const useStep = ({ initial = 0, max }: Props) => {
   const [currentStep, setCurrentStep] = useState(initial);
 
-  const prev = () => {
+  function prev(n?: number) {
     if (0 >= currentStep) return;
-    setCurrentStep((prevStep) => prevStep - 1);
-  };
+    setCurrentStep((prevStep) => prevStep - (n ? n : 1));
+  }
 
-  const next = () => {
+  function next(n?: number) {
     if (currentStep >= (max || Infinity)) return;
-    setCurrentStep((prevStep) => prevStep + 1);
-  };
+    setCurrentStep((prevStep) => prevStep + (n ? n : 1));
+  }
 
   return { currentStep, setCurrentStep, prev, next };
 };

--- a/src/hooks/storage/useLocalStorage.ts
+++ b/src/hooks/storage/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 /**
  * @description 페이지 새로 고침을 통해 상태가 유지되도록 로컬 저장소에 동기화합니다.
@@ -41,23 +41,7 @@ function useLocalStorage<T>(key: string, initialValue: T) {
     }
   };
 
-  const [hasMount, setHasMount] = useState(false);
-  // const isMounted = useRef(false);
-
-  useEffect(() => {
-    setHasMount(true);
-  }, []);
-
-  // useDidMount(() => {
-  //   isMounted.current = true;
-  // });
-
-  if (hasMount) {
-    return [storedValue, setValue] as const;
-  }
-
-  // mount 되기 이전에는 초기 값 반환
-  return [initialValue, setValue] as const;
+  return [storedValue, setValue] as const;
 }
 
 export default useLocalStorage;

--- a/src/hooks/storage/useLocalStorage.ts
+++ b/src/hooks/storage/useLocalStorage.ts
@@ -25,11 +25,17 @@ function useLocalStorage<T>(key: string, initialValue: T) {
 
   const setValue = (value: T | ((val: T) => T)) => {
     try {
-      const valueToStore = value instanceof Function ? value(storedValue) : value;
-      setStoredValue(valueToStore);
-      if (typeof window !== 'undefined') {
-        window.localStorage.setItem(key, JSON.stringify(valueToStore));
-      }
+      setStoredValue((prev) => {
+        const nextValue = value instanceof Function ? value(prev) : value;
+
+        if (nextValue === null) {
+          localStorage.removeItem(key);
+        } else {
+          localStorage.setItem(key, JSON.stringify(nextValue));
+        }
+
+        return nextValue;
+      });
     } catch (error) {
       console.error(error);
     }

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -7,6 +7,7 @@ import { errorMessage } from '~/exceptions/messages';
 import { type ApiErrorScheme } from '~/exceptions/type';
 import { isProd } from '~/utils/common';
 
+// const DEVELOPMENT_API_URL = 'https://api.nalab.me/v1';
 const DEVELOPMENT_API_URL = 'https://api.nalab.me/mock';
 const PRODUCTION_API_URL = 'https://api.nalab.me/v1';
 

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -9,7 +9,8 @@ import { isProd } from '~/utils/common';
 
 // const DEVELOPMENT_API_URL = 'https://api.nalab.me/v1';
 const DEVELOPMENT_API_URL = 'https://api.nalab.me/mock';
-const PRODUCTION_API_URL = 'https://api.nalab.me/v1';
+const PRODUCTION_API_URL = 'https://api.nalab.me/mock';
+// const PRODUCTION_API_URL = 'https://api.nalab.me/v1';
 
 const instance = axios.create({
   baseURL: isProd(process.env.NODE_ENV) ? PRODUCTION_API_URL : DEVELOPMENT_API_URL,

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -7,7 +7,7 @@ import { errorMessage } from '~/exceptions/messages';
 import { type ApiErrorScheme } from '~/exceptions/type';
 import { isProd } from '~/utils/common';
 
-const DEVELOPMENT_API_URL = 'https://api.nalab.me/v1';
+const DEVELOPMENT_API_URL = 'https://api.nalab.me/mock';
 const PRODUCTION_API_URL = 'https://api.nalab.me/v1';
 
 const instance = axios.create({
@@ -38,7 +38,7 @@ const interceptorResponseFulfilled = (res: AxiosResponse) => {
 
 // Response interceptor
 const interceptorResponseRejected = (error: AxiosError<ApiErrorScheme>) => {
-  if (error.response?.data?.['response-message']) {
+  if (error.response?.data?.['response_messages']) {
     return Promise.reject(new ApiException(error.response.data, error.response.status));
   }
 

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -7,10 +7,8 @@ import { errorMessage } from '~/exceptions/messages';
 import { type ApiErrorScheme } from '~/exceptions/type';
 import { isProd } from '~/utils/common';
 
-// const DEVELOPMENT_API_URL = 'https://api.nalab.me/v1';
-const DEVELOPMENT_API_URL = 'https://api.nalab.me/mock';
-const PRODUCTION_API_URL = 'https://api.nalab.me/mock';
-// const PRODUCTION_API_URL = 'https://api.nalab.me/v1';
+const DEVELOPMENT_API_URL = 'https://api.nalab.me/v1';
+const PRODUCTION_API_URL = 'https://api.nalab.me/v1';
 
 const instance = axios.create({
   baseURL: isProd(process.env.NODE_ENV) ? PRODUCTION_API_URL : DEVELOPMENT_API_URL,

--- a/src/pages/review/LoadedSurvey.tsx
+++ b/src/pages/review/LoadedSurvey.tsx
@@ -4,8 +4,6 @@ import { css } from '@emotion/react';
 import { AnimatePresence } from 'framer-motion';
 
 import { type Softskills } from '~/components/graphic/softskills/type';
-import ChoiceQuestion from '~/features/review/steps/ChoiceQuestion';
-import Intro from '~/features/review/steps/Intro';
 import Last from '~/features/review/steps/Last';
 import { type Position as PositionType } from '~/features/review/steps/type';
 import StepStatus from '~/features/review/StepStatus';
@@ -14,27 +12,12 @@ import useInjectedElementStep from '~/hooks/step/useInjectedElementStep';
 
 const Cowork = dynamic(() => import('~/features/review/steps/Cowork'), { ssr: false });
 const Position = dynamic(() => import('~/features/review/steps/Position'), { ssr: false });
+const QuestionIntro = dynamic(() => import('~/features/review/steps/QuestionIntro'), { ssr: false });
 const Softskill = dynamic(() => import('~/features/review/steps/Softskill'), { ssr: false });
 const ShortQuestion = dynamic(() => import('~/features/review/steps/ShortQuestion'), { ssr: false });
-const QuestionIntro = dynamic(() => import('~/features/review/steps/QuestionIntro'), { ssr: false });
+const ChoiceQuestion = dynamic(() => import('~/features/review/steps/ChoiceQuestion'), { ssr: false });
 
 const DEFAULT_STEP_LENGTH = 6;
-
-// const MOCKQ = [
-//   {
-//     type: 'choice',
-//     question_id: 2,
-//     order: 2,
-//     max_selectable_count: 2,
-//     title: 'string',
-//     choices: [
-//       { choice_id: 1, order: 1, content: 'ui' },
-//       { choice_id: 2, order: 2, content: 'ux' },
-//       { choice_id: 3, order: 3, content: 'aa' },
-//       { choice_id: 4, order: 4, content: 'dd' },
-//     ],
-//   },
-// ];
 
 const LoadedSurvey = ({ target, question, question_count }: SurveyRequest) => {
   const { isCoworked, setIsCoworked } = useIsCowork();
@@ -46,7 +29,7 @@ const LoadedSurvey = ({ target, question, question_count }: SurveyRequest) => {
 
   const { currentElement, currentStep } = useInjectedElementStep({
     elements: [
-      <Intro key="intro" nickname={target.nickname} />,
+      // <Intro key="intro" nickname={target.nickname} />,
       <Cowork key="cowork" isCoworked={isCoworked} setIsCoworked={setIsCoworked} />,
       <Position key="position" position={position} setPosition={setPosition} />,
       <QuestionIntro key="question-intro" />,
@@ -55,7 +38,7 @@ const LoadedSurvey = ({ target, question, question_count }: SurveyRequest) => {
         selectedSoftskills={selectedSoftskills}
         setSelectedSoftskills={setSelectedSoftskills}
       />,
-      // TODO: 첫 번째 기본 질문 대응
+      // TODO: form_type 대응
       ...question.map((eachQuestion, index) =>
         eachQuestion.type === 'short' ? (
           <ShortQuestion

--- a/src/pages/review/LoadedSurvey.tsx
+++ b/src/pages/review/LoadedSurvey.tsx
@@ -4,6 +4,7 @@ import { css } from '@emotion/react';
 import { AnimatePresence } from 'framer-motion';
 
 import { type Softskills } from '~/components/graphic/softskills/type';
+import Intro from '~/features/review/steps/Intro';
 import Last from '~/features/review/steps/Last';
 import { type Position as PositionType } from '~/features/review/steps/type';
 import StepStatus from '~/features/review/StepStatus';
@@ -29,7 +30,7 @@ const LoadedSurvey = ({ target, question, question_count }: SurveyRequest) => {
 
   const { currentElement, currentStep } = useInjectedElementStep({
     elements: [
-      // <Intro key="intro" nickname={target.nickname} />,
+      <Intro key="intro" nickname={target.nickname} />,
       <Cowork key="cowork" isCoworked={isCoworked} setIsCoworked={setIsCoworked} />,
       <Position key="position" position={position} setPosition={setPosition} />,
       <QuestionIntro key="question-intro" />,
@@ -43,6 +44,7 @@ const LoadedSurvey = ({ target, question, question_count }: SurveyRequest) => {
         eachQuestion.type === 'short' ? (
           <ShortQuestion
             key={eachQuestion.question_id}
+            questionId={eachQuestion.question_id}
             headerTitle={eachQuestion.title}
             setReplies={setEachQuestionAnswer(eachQuestion.question_id)}
             startMessages={[
@@ -56,6 +58,7 @@ const LoadedSurvey = ({ target, question, question_count }: SurveyRequest) => {
             key={eachQuestion.question_id}
             nickname={target.nickname}
             title={eachQuestion.title}
+            selectedChoicesId={(questionAnswers[index] as ChoiceQuestionAnswer).choices}
             choices={eachQuestion.choices}
             setChoices={setEachQuestionAnswer(eachQuestion.question_id)}
             max_selectable_count={eachQuestion.max_selectable_count}

--- a/src/pages/review/LoadedSurvey.tsx
+++ b/src/pages/review/LoadedSurvey.tsx
@@ -8,7 +8,7 @@ import Intro from '~/features/review/steps/Intro';
 import Last from '~/features/review/steps/Last';
 import { type Position as PositionType } from '~/features/review/steps/type';
 import StepStatus from '~/features/review/StepStatus';
-import { type Request as SurveyRequest } from '~/hooks/api/surveys/useGetSurveyById';
+import { type Response as SurveyResponse } from '~/hooks/api/surveys/useGetSurveyById';
 import useInjectedElementStep from '~/hooks/step/useInjectedElementStep';
 
 const Cowork = dynamic(() => import('~/features/review/steps/Cowork'), { ssr: false });
@@ -20,7 +20,7 @@ const ChoiceQuestion = dynamic(() => import('~/features/review/steps/ChoiceQuest
 
 const DEFAULT_STEP_LENGTH = 6;
 
-const LoadedSurvey = ({ target, question, question_count }: SurveyRequest) => {
+const LoadedSurvey = ({ target, question, question_count }: SurveyResponse) => {
   const { isCoworked, setIsCoworked } = useIsCowork();
   const { position, setPosition } = usePosition();
   const { selectedSoftskills, setSelectedSoftskills } = useSoftskills();
@@ -130,7 +130,7 @@ interface ChoiceQuestionAnswer {
 
 type QuestionAnswer = ShortQuestionAnswer | ChoiceQuestionAnswer;
 
-const useQuestionAnswers = ({ question }: Pick<SurveyRequest, 'question'>) => {
+const useQuestionAnswers = ({ question }: Pick<SurveyResponse, 'question'>) => {
   const [questionAnswers, setQuestionAnswers] = useState<QuestionAnswer[]>(
     question.map((eachQuestion) =>
       eachQuestion.type === 'short'

--- a/src/pages/review/LoadedSurvey.tsx
+++ b/src/pages/review/LoadedSurvey.tsx
@@ -66,6 +66,7 @@ const LoadedSurvey = ({ target, question, question_count }: SurveyRequest) => {
           />
         ),
       ),
+      // TODO: post 이후 localStoreage short message 비우기
       <Last key="last" onSubmit={() => console.warn(questionAnswers)} />,
     ],
   });

--- a/src/pages/review/index.page.tsx
+++ b/src/pages/review/index.page.tsx
@@ -57,14 +57,12 @@ const useSurveyIdValidation = () => {
     setValidatedId(id);
   }, [isReady]);
 
-  const query = useGetSurveyById(validatedId as string, { enabled: Boolean(validatedId) });
-
-  useDidUpdate(() => {
-    if (!query.isLoading) return;
-    if (query.isError) {
+  const query = useGetSurveyById(validatedId as string, {
+    enabled: Boolean(validatedId),
+    onError: () => {
       handleInvalidateId();
-    }
-  }, [query.isLoading, query.isError]);
+    },
+  });
 
   return query;
 };


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

https://www.notion.so/depromeet/bb780f311d5e48fca1291f22e588eef2?pvs=4

## 🎉 변경 사항

- 뒤로가기 시 이전에 선택한 값을 유지해요
  - 주관식 질문을 제외하고 `LoadedSurvey`에서 관리하고 있기 때문에 로컬스토리지를 사용하지 않아요

  - 주관식 질문은 `other`이 보낸 메시지까지 LoadedSurvey에서 관리하는 것이 불필요하다고 생각돼 로컬스토리지를 사용했어요

- 인트로가 껴 있는 부분이 존재해 `useStep`의 인터페이스를 변경했어요
  - prev 혹은 next 시에 n을 주입해 여러 단계 이동할 수 있도록 했어요

- `useLocalStorage`의 몇가지 로직을 변경했어요
  - set 시에 이전 값을 state 값으로 제공되어 있어서 클로저안에서 보장하도록 했어요
  - 마운트 이전에 초기값을 제공하는 로직을 지웠어요
    - 타 라이브러리를 참고한 경우 해당 로직이 필요해 보이지 않았는데, 확인이 필요해요

> @sumi-0011 어떤 부분을 확인해야하는지 말씀해 주시면 확인해 볼게요


## 📚 참고

https://slash.page/ko/libraries/react/react/src/hooks/usestoragestate.i18n/
https://github.com/toss/slash/blob/main/packages/react/react/src/hooks/useStorageState.ts