### PR TITLE
결과 페이지 api hook 및 `remotes` dir 생성

### DIFF
--- a/src/features/review/steps/ChoiceQuestion.tsx
+++ b/src/features/review/steps/ChoiceQuestion.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/react';
 import { m } from 'framer-motion';
 
 import { defaultFadeInVariants } from '~/constants/motions';
-import { type Choice } from '~/hooks/api/surveys/useGetSurveyById';
 import useDidUpdate from '~/hooks/lifeCycle/useDidUpdate';
 
 import BottomNavigation from '../BottomNavigation';

--- a/src/features/review/steps/Position.tsx
+++ b/src/features/review/steps/Position.tsx
@@ -10,7 +10,7 @@ import theme from '~/styles/theme';
 import BottomNavigation from '../BottomNavigation';
 import QuestionHeader from '../QuestionHeader';
 import PositionCard from './position/PositionCard';
-import { type Position as PositionType, type StepProps } from './type';
+import { type StepProps } from './type';
 
 import '@egjs/react-flicking/dist/flicking.css';
 
@@ -20,7 +20,7 @@ const IMAGE_BASE_URL = '/images/review/position';
 
 const positionCards: PositionCardProps[] = [
   {
-    value: 'product-manager',
+    value: 'pm',
     title: 'PM',
     subTitle: '기획자',
     imgSrc: { default: `${IMAGE_BASE_URL}/pm.png`, webp: `${IMAGE_BASE_URL}/pm.webp` },
@@ -36,7 +36,7 @@ const positionCards: PositionCardProps[] = [
     checkedBackgroundColor: theme.colors.pink,
   },
   {
-    value: 'programmer',
+    value: 'developer',
     title: 'Developer',
     subTitle: '개발자',
     imgSrc: { default: `${IMAGE_BASE_URL}/developer.png`, webp: `${IMAGE_BASE_URL}/developer.webp` },
@@ -44,7 +44,7 @@ const positionCards: PositionCardProps[] = [
     checkedBackgroundColor: theme.colors.skyblue,
   },
   {
-    value: 'other',
+    value: 'others',
     title: 'Others',
     subTitle: '지인',
     imgSrc: { default: `${IMAGE_BASE_URL}/others.png`, webp: `${IMAGE_BASE_URL}/others.webp` },
@@ -54,8 +54,8 @@ const positionCards: PositionCardProps[] = [
 ];
 
 interface Props extends StepProps {
-  position: PositionType | null;
-  setPosition: Dispatch<SetStateAction<PositionType | null>>;
+  position: ReviewerPosition | null;
+  setPosition: Dispatch<SetStateAction<ReviewerPosition | null>>;
 }
 
 const Position = ({ prev, next, position, setPosition }: Props) => {
@@ -68,7 +68,7 @@ const Position = ({ prev, next, position, setPosition }: Props) => {
       return;
     }
 
-    const currentPosition = e.target.value as PositionType;
+    const currentPosition = e.target.value as ReviewerPosition;
     setPosition(currentPosition);
   };
 

--- a/src/features/review/steps/position/Checkbox.tsx
+++ b/src/features/review/steps/position/Checkbox.tsx
@@ -3,10 +3,8 @@ import { css, type Theme, useTheme } from '@emotion/react';
 
 import CheckIcon from '~/components/icons/CheckIcon';
 
-import { type Position } from '../type';
-
 interface Props {
-  value: Position;
+  value: ReviewerPosition;
   checked: boolean;
   onChange: ChangeEventHandler<HTMLInputElement>;
   checkedColor: string;

--- a/src/features/review/steps/type.ts
+++ b/src/features/review/steps/type.ts
@@ -3,8 +3,6 @@ export interface StepProps {
   prev?: () => void;
 }
 
-export type Position = 'designer' | 'product-manager' | 'programmer' | 'other';
-
 export interface IsLastQuestion {
   isLastQuestion?: boolean;
 }

--- a/src/hooks/api/feedbacks/useGetAllFeedbacksBySurveyId.ts
+++ b/src/hooks/api/feedbacks/useGetAllFeedbacksBySurveyId.ts
@@ -1,0 +1,50 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+import { get } from '~/libs/api';
+
+interface DefaultFeedback {
+  feedback_id: number;
+  created_at: string;
+  is_read: boolean;
+  reviewer: ReviewerWithId;
+}
+
+interface ChoiceFeedback extends DefaultFeedback {
+  choice_id: number[];
+}
+
+interface ShortFeedback extends DefaultFeedback {
+  reply: string[];
+}
+
+interface DefaultQuestionFeedback {
+  question_id: number;
+  order: number;
+  form_type: QuestionFormType;
+  title: string;
+}
+
+interface ChoiceQuestionFeedback extends DefaultQuestionFeedback {
+  type: 'choice';
+  choices: Choice[];
+  feedbacks: ChoiceFeedback[];
+}
+
+interface ShortQuestionFeedback extends DefaultQuestionFeedback {
+  type: 'short';
+  feedbacks: ShortFeedback[];
+}
+
+interface Response {
+  question_feedback: (ChoiceQuestionFeedback | ShortQuestionFeedback)[];
+}
+
+const useGetAllFeedbacksBySurveyId = (surveyId: string, options?: UseQueryOptions<Response>) => {
+  return useQuery<Response>({
+    queryKey: ['feedbacks', surveyId],
+    queryFn: () => get<Response>(`/feedbacks?survey-id=${surveyId}`),
+    ...options,
+  });
+};
+
+export default useGetAllFeedbacksBySurveyId;

--- a/src/hooks/api/feedbacks/useGetFeedbackById.ts
+++ b/src/hooks/api/feedbacks/useGetFeedbackById.ts
@@ -2,15 +2,19 @@ import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 
 import { get } from '~/libs/api';
 
-interface Request {
+interface Response {
   feedback_id: number;
   created_at: string;
   reviewer: Reviewer;
   question: QuestionWithIsRead[];
 }
 
-const useGetFeedbackById = (id: number, options?: UseQueryOptions<Request>) => {
-  return useQuery<Request>({ queryKey: ['feedback', id], queryFn: () => get<Request>(`/feedbacks/${id}`), ...options });
+const useGetFeedbackById = (id: number, options?: UseQueryOptions<Response>) => {
+  return useQuery<Response>({
+    queryKey: ['feedback', id],
+    queryFn: () => get<Response>(`/feedbacks/${id}`),
+    ...options,
+  });
 };
 
 export default useGetFeedbackById;

--- a/src/hooks/api/feedbacks/useGetFeedbackById.ts
+++ b/src/hooks/api/feedbacks/useGetFeedbackById.ts
@@ -1,0 +1,16 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+import { get } from '~/libs/api';
+
+interface Request {
+  feedback_id: number;
+  created_at: string;
+  reviewer: Reviewer;
+  question: QuestionWithIsRead[];
+}
+
+const useGetFeedbackById = (id: number, options?: UseQueryOptions<Request>) => {
+  return useQuery<Request>({ queryKey: ['feedback', id], queryFn: () => get<Request>(`/feedbacks/${id}`), ...options });
+};
+
+export default useGetFeedbackById;

--- a/src/hooks/api/feedbacks/useGetFeedbackSummaryBySurveyId.ts
+++ b/src/hooks/api/feedbacks/useGetFeedbackSummaryBySurveyId.ts
@@ -1,0 +1,18 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+import { get } from '~/libs/api';
+
+interface Response {
+  all_feedback_count: number;
+  new_feedback_count: number;
+}
+
+const useGetFeedbackSummaryBySurveyId = (surveyId: string, options?: UseQueryOptions<Response>) => {
+  return useQuery<Response>({
+    queryKey: ['feedbacks summary', surveyId],
+    queryFn: () => get<Response>(`/feedbacks/summary?survey-id=${surveyId}`),
+    ...options,
+  });
+};
+
+export default useGetFeedbackSummaryBySurveyId;

--- a/src/hooks/api/reviewers/useGetAllReviewersBySurveyId.ts
+++ b/src/hooks/api/reviewers/useGetAllReviewersBySurveyId.ts
@@ -1,0 +1,24 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+import { get } from '~/libs/api';
+
+interface Feedback {
+  feedback_id: number;
+  created_at: string;
+  is_read: boolean;
+  reviewer: Reviewer;
+}
+
+interface Response {
+  feedbacks: Feedback[];
+}
+
+const useGetAllReviewersBySurveyId = (surveyId: string, options?: UseQueryOptions<Response>) => {
+  return useQuery<Response>({
+    queryKey: ['reviewers', surveyId],
+    queryFn: () => get<Response>(`/reviewers?survey-id=${surveyId}`),
+    ...options,
+  });
+};
+
+export default useGetAllReviewersBySurveyId;

--- a/src/hooks/api/reviewers/useGetReviewersSummaryBySurveyId.ts
+++ b/src/hooks/api/reviewers/useGetReviewersSummaryBySurveyId.ts
@@ -1,0 +1,27 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+import { get } from '~/libs/api';
+
+interface CollaborationExperience {
+  yes: number;
+  no: number;
+}
+
+type Position = {
+  [key in ReviewerPosition]: number;
+};
+
+interface Response {
+  collaboration_experience: CollaborationExperience;
+  position: Position;
+}
+
+const useGetReviewersSummaryBySurveyId = (surveyId: string, options?: UseQueryOptions<Response>) => {
+  return useQuery<Response>({
+    queryKey: ['reviewers summary', surveyId],
+    queryFn: () => get<Response>(`/reviewers/summary?survey-id=${surveyId}`),
+    ...options,
+  });
+};
+
+export default useGetReviewersSummaryBySurveyId;

--- a/src/hooks/api/surveys/useGetSurveyById.ts
+++ b/src/hooks/api/surveys/useGetSurveyById.ts
@@ -14,12 +14,6 @@ interface ShortQuestion {
   title: string;
 }
 
-export interface Choice {
-  choice_id: number;
-  order: number;
-  content: string;
-}
-
 interface ChoiceQuestion {
   type: 'choice';
   question_id: number;

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -11,6 +11,74 @@ export default function Home() {
     <main css={loginPageWrapperCss}>
       <Logo css={logoCss} />
 
+      {/* NOTE: 질문 폼 생성을 위한 임시 코드 */}
+      {/* <button
+        type="button"
+        onClick={() =>
+          post('/surveys', {
+            question_count: 4,
+            question: [
+              {
+                type: 'short',
+                form_type: 'strength',
+                title: '저는 UX, UI, GUI 중에 어떤 분야에 더 강점이 있나요?',
+                order: 5,
+              },
+              {
+                type: 'choice',
+                form_type: 'custom',
+                title: '저는 UI, UI, GUI 중에 어떤 분야를 가장 잘하는 것 같나요?',
+                choices: [
+                  {
+                    content: 'UI',
+                    order: 1,
+                  },
+                  {
+                    content: 'UX',
+                    order: 2,
+                  },
+                ],
+                max_selectable_count: 1,
+                order: 6,
+              },
+              {
+                type: 'short',
+                form_type: 'custom',
+                title: '이건 테스트 입니다',
+                order: 7,
+              },
+              {
+                type: 'choice',
+                form_type: 'custom',
+                title: '저는 UI, UI, GUI 중에 어떤 분야를 가장 잘하는 것 같나요?',
+                choices: [
+                  {
+                    content: 'UI',
+                    order: 1,
+                  },
+                  {
+                    content: 'UX',
+                    order: 2,
+                  },
+                  {
+                    content: 'TEST',
+                    order: 3,
+                  },
+                  {
+                    content: 'TEST2',
+                    order: 4,
+                  },
+                ],
+                max_selectable_count: 2,
+                order: 8,
+              },
+            ],
+          })
+        }
+      >
+        test
+      </button> */}
+
       <section css={ctaWrapperCss}>
         <CTAButton color="blue">질문 폼 생성으로 시작하기</CTAButton>
         <KakaoLoginButton />

--- a/src/pages/result/index.page.tsx
+++ b/src/pages/result/index.page.tsx
@@ -1,0 +1,17 @@
+import { type ReactElement } from 'react';
+
+import LayoutPaddingTo23 from '~/components/layout/LayoutPaddingTo23';
+
+const Result = () => {
+  // const { data } = useGetFeedbackById(1);
+  // const { data } = useGetAllFeedbacksBySurveyId('123');
+  // const { data } = useGetAllReviewersBySurveyId('123');
+  // const { data } = useGetReviewersSummaryBySurveyId('123');
+  // const { data } = useGetFeedbackSummaryBySurveyId('123');
+
+  return <div>result</div>;
+};
+
+export default Result;
+
+Result.getLayout = (page: ReactElement) => <LayoutPaddingTo23>{page}</LayoutPaddingTo23>;

--- a/src/pages/review/LoadedSurvey.tsx
+++ b/src/pages/review/LoadedSurvey.tsx
@@ -7,7 +7,6 @@ import { type Softskills } from '~/components/graphic/softskills/type';
 import ChoiceQuestion from '~/features/review/steps/ChoiceQuestion';
 import Intro from '~/features/review/steps/Intro';
 import Last from '~/features/review/steps/Last';
-import { type Position as PositionType } from '~/features/review/steps/type';
 import StepStatus from '~/features/review/StepStatus';
 import { type Request as SurveyRequest } from '~/hooks/api/surveys/useGetSurveyById';
 import useInjectedElementStep from '~/hooks/step/useInjectedElementStep';
@@ -113,7 +112,7 @@ const useIsCowork = () => {
 };
 
 const usePosition = () => {
-  const [position, setPosition] = useState<PositionType | null>(null);
+  const [position, setPosition] = useState<ReviewerPosition | null>(null);
 
   return { position, setPosition };
 };

--- a/src/remotes/question.d.ts
+++ b/src/remotes/question.d.ts
@@ -1,0 +1,39 @@
+type QuestionFormType = 'tendency' | 'strength' | 'custom';
+
+interface Choice {
+  choice_id: number;
+  content: string;
+  order: number;
+}
+
+interface DefaultQuestion {
+  question_id: number;
+  form_type: QuestionFormType;
+  title: string;
+  order: number;
+}
+
+interface ShortQuestion extends DefaultQuestion {
+  type: 'short';
+  reply: string[];
+}
+
+/**
+ * max_selectable_count 없음
+ */
+interface ChoiceQuestion extends DefaultQuestion {
+  type: 'choice';
+  choices: Choice[];
+}
+
+type Question = ShortQuestion | ChoiceQuestion;
+
+interface WithIsRead<T> extends T {
+  is_read: boolean;
+}
+
+type ShortQuestionWithIsRead = WithIsRead<ShortQuestion>;
+
+type ChoiceQuestionWithIsRead = WithIsRead<ChoiceQuestion>;
+
+type QuestionWithIsRead = ShortQuestionWithIsRead | ChoiceQuestionWithIsRead;

--- a/src/remotes/reviewer.d.ts
+++ b/src/remotes/reviewer.d.ts
@@ -1,0 +1,7 @@
+type ReviewerPosition = 'designer' | 'developer' | 'product-manager' | 'others';
+
+interface Reviewer {
+  nickname: string;
+  collaboration_experience: boolean;
+  position: ReviewerPosition;
+}

--- a/src/remotes/reviewer.d.ts
+++ b/src/remotes/reviewer.d.ts
@@ -1,7 +1,14 @@
 type ReviewerPosition = 'designer' | 'developer' | 'product-manager' | 'others';
 
+/**
+ * reviewer_id 없음
+ */
 interface Reviewer {
   nickname: string;
   collaboration_experience: boolean;
   position: ReviewerPosition;
+}
+
+interface ReviewerWithId extends Reviewer {
+  reviewer_id: number;
 }

--- a/src/remotes/reviewer.d.ts
+++ b/src/remotes/reviewer.d.ts
@@ -1,4 +1,4 @@
-type ReviewerPosition = 'designer' | 'developer' | 'product-manager' | 'others';
+type ReviewerPosition = 'designer' | 'developer' | 'pm' | 'others';
 
 /**
  * reviewer_id 없음


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

- close #254 
- close #255
- close #256
- close #257
- close #258

## 🎉 변경 사항

- `remotes` dir을 생성했어요
  - 일반적으로 그리고 자주 사용되는 remote data scheme을 모으고, 형태의 원천으로 삼기 위함이에요

  - 각 api 요청마다 추가되는 부분은 담지 않는 형태로 유지하고자 했어요
    - 필요한 경우 확장해서 사용하면 좋을 거 같아요 
  - `reviewer` 같은 경우에는 간단히 리팩토링 해 봤어요

- close 태그에 걸린 api 요청 hook을 만들었어요


### 사용 방법

```tsx
  const { data } = useGetFeedbackById(1);
  const { data } = useGetAllFeedbacksBySurveyId('123');
  const { data } = useGetAllReviewersBySurveyId('123');
  const { data } = useGetReviewersSummaryBySurveyId('123');
  const { data } = useGetFeedbackSummaryBySurveyId('123');
```