### PR TITLE
카카오 로그인 로직 훅으로 분리

### DIFF
--- a/src/components/kakaoLoginButton/KakaoLoginButton.tsx
+++ b/src/components/kakaoLoginButton/KakaoLoginButton.tsx
@@ -1,43 +1,15 @@
-import React, { useEffect } from 'react';
-import { signIn, signOut, useSession } from 'next-auth/react';
+import React from 'react';
+import { signIn } from 'next-auth/react';
 import { css } from '@emotion/react';
 
-import { LOCAL_STORAGE_KEY } from '~/constants/storage';
-import { post } from '~/libs/api';
+import useKakaoLogin from '~/components/kakaoLoginButton/useKakaoLogin';
 import colors from '~/styles/color';
 import { BODY_1 } from '~/styles/typo';
 
-interface Token {
-  token_type: string;
-  access_token: string;
-}
-
 const KakaoLoginButton = () => {
-  const { data: session } = useSession();
+  const { logOutHandler, isLoginState } = useKakaoLogin();
 
-  const getTokenHandler = async () => {
-    const token: Token = await post('/oauth/kakao', {
-      nickname: session?.user?.name,
-      email: session?.user?.email,
-    });
-
-    localStorage.setItem(LOCAL_STORAGE_KEY.accessToken, token.access_token);
-  };
-
-  const logOutHandler = () => {
-    signOut();
-    localStorage.removeItem(LOCAL_STORAGE_KEY.accessToken);
-  };
-
-  useEffect(() => {
-    if (session) {
-      getTokenHandler();
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session]);
-
-  if (session) {
+  if (isLoginState) {
     return (
       <div css={KakaoLoginWrapper}>
         <button type="button" onClick={logOutHandler}>

--- a/src/components/kakaoLoginButton/KakaoLoginButton.tsx
+++ b/src/components/kakaoLoginButton/KakaoLoginButton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { signIn } from 'next-auth/react';
 import { css } from '@emotion/react';
 
 import useKakaoLogin from '~/components/kakaoLoginButton/useKakaoLogin';
@@ -7,7 +6,7 @@ import colors from '~/styles/color';
 import { BODY_1 } from '~/styles/typo';
 
 const KakaoLoginButton = () => {
-  const { logOutHandler, isLoginState } = useKakaoLogin();
+  const { logOutHandler, loginHandler, isLoginState } = useKakaoLogin();
 
   if (isLoginState) {
     return (
@@ -22,7 +21,7 @@ const KakaoLoginButton = () => {
   return (
     <div css={KakaoLoginWrapper}>
       이미 계정이 있다면?
-      <button type="button" css={KakaoLoginButtonCss} onClick={() => signIn('kakao')}>
+      <button type="button" css={KakaoLoginButtonCss} onClick={loginHandler}>
         카카오 로그인하기
       </button>
     </div>

--- a/src/components/kakaoLoginButton/useKakaoLogin.tsx
+++ b/src/components/kakaoLoginButton/useKakaoLogin.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { signOut, useSession } from 'next-auth/react';
+
+import { LOCAL_STORAGE_KEY } from '~/constants/storage';
+import { post } from '~/libs/api';
+
+interface Token {
+  token_type: string;
+  access_token: string;
+}
+
+const useKakaoLogin = () => {
+  const { data: session } = useSession();
+
+  const isLoginState = !!session;
+
+  const getTokenHandler = async () => {
+    const token: Token = await post('/oauth/kakao', {
+      nickname: session?.user?.name,
+      email: session?.user?.email,
+    });
+
+    localStorage.setItem(LOCAL_STORAGE_KEY.accessToken, token.access_token);
+  };
+
+  const logOutHandler = () => {
+    signOut();
+    localStorage.removeItem(LOCAL_STORAGE_KEY.accessToken);
+  };
+
+  useEffect(() => {
+    if (session) {
+      getTokenHandler();
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session]);
+
+  return {
+    logOutHandler,
+    isLoginState,
+  };
+};
+
+export default useKakaoLogin;

--- a/src/components/kakaoLoginButton/useKakaoLogin.tsx
+++ b/src/components/kakaoLoginButton/useKakaoLogin.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { signOut, useSession } from 'next-auth/react';
+import { signIn, signOut, useSession } from 'next-auth/react';
 
 import { LOCAL_STORAGE_KEY } from '~/constants/storage';
 import { post } from '~/libs/api';
@@ -28,6 +28,10 @@ const useKakaoLogin = () => {
     localStorage.removeItem(LOCAL_STORAGE_KEY.accessToken);
   };
 
+  const loginHandler = () => {
+    signIn('kakao');
+  };
+
   useEffect(() => {
     if (session) {
       getTokenHandler();
@@ -38,6 +42,7 @@ const useKakaoLogin = () => {
 
   return {
     logOutHandler,
+    loginHandler,
     isLoginState,
   };
 };


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
카카오 로그인 로직이 필요한 부분이 추가적으로 생겨, 훅으로 분리하여 중복 코드 없이 사용하려고 하였습니다
## 🎉 변경 사항
- `KakaoButton` 컴포넌트에 view와 같이 있던 카카오 로그인 로직을 hook으로 분리하였어요.
- `session`이 있는 경우에 로그인 상태로 간주하는 것으로 확인했고, `isLoginState`라는 변수를 만들어 로그인 상태를 감지하도록 수정했습니다. 
```
const isLoginState = !!session;
```