### PR TITLE
review - 질문 폼 생성 api 이후 대응

### DIFF
--- a/src/features/review/steps/ChoiceQuestion.tsx
+++ b/src/features/review/steps/ChoiceQuestion.tsx
@@ -57,7 +57,12 @@ const ChoiceQuestion = ({
           ))}
         </div>
       </m.section>
-      <BottomNavigation onBackClick={() => prev?.()} onNextClick={() => next?.()} isLastQuestion={isLastQuestion} />
+      <BottomNavigation
+        onBackClick={() => prev?.()}
+        isNextDisabled={selectedChoicesId.length === 0}
+        onNextClick={() => next?.()}
+        isLastQuestion={isLastQuestion}
+      />
     </>
   );
 };

--- a/src/features/review/steps/ChoiceQuestion.tsx
+++ b/src/features/review/steps/ChoiceQuestion.tsx
@@ -17,7 +17,7 @@ interface Props extends StepProps, IsLastQuestion {
   title: ComponentProps<typeof QuestionHeader>['title'];
   selectedChoicesId: string[];
   choices: Choice[];
-  max_selection_count: number;
+  max_selectable_count: number;
   setChoices: (setStateAction: (prevState: string[]) => string[]) => void;
 }
 
@@ -26,13 +26,13 @@ const ChoiceQuestion = ({
   prev,
   next,
   title,
-  max_selection_count,
+  max_selectable_count,
   selectedChoicesId,
   choices,
   setChoices,
   isLastQuestion = false,
 }: Props) => {
-  const { onChange } = useChoices({ max_selection_count, selectedChoicesId, setChoices });
+  const { onChange } = useChoices({ max_selectable_count, selectedChoicesId, setChoices });
 
   useDidMount(() => {
     recordEvent({ action: '리뷰어 - 객관식 질문' });
@@ -42,7 +42,7 @@ const ChoiceQuestion = ({
     <>
       <QuestionHeader title={title} subTitle={`${nickname}님이 직접 입력한 질문이에요.`} />
       <m.section css={sectionCss} variants={defaultFadeInVariants} initial="initial" animate="animate" exit="exit">
-        <MaxSelectableSmall max={max_selection_count} />
+        <MaxSelectableSmall max={max_selectable_count} />
 
         <div css={choiceWrapperCss}>
           {choices.map(({ choice_id, content }) => (
@@ -85,9 +85,9 @@ const choiceWrapperCss = css`
   margin-top: 12px;
 `;
 
-type UseChoicesProps = Pick<Props, 'max_selection_count' | 'selectedChoicesId' | 'setChoices'>;
+type UseChoicesProps = Pick<Props, 'max_selectable_count' | 'selectedChoicesId' | 'setChoices'>;
 
-const useChoices = ({ max_selection_count, selectedChoicesId, setChoices }: UseChoicesProps) => {
+const useChoices = ({ max_selectable_count, selectedChoicesId, setChoices }: UseChoicesProps) => {
   const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     const choiceId = e.target.value;
 
@@ -97,7 +97,7 @@ const useChoices = ({ max_selection_count, selectedChoicesId, setChoices }: UseC
       return;
     }
 
-    if (selectedChoicesId.length >= max_selection_count) {
+    if (selectedChoicesId.length >= max_selectable_count) {
       setChoices((prev) => [...prev.slice(1), choiceId]);
 
       return;

--- a/src/features/review/steps/ReviewSteps.stories.tsx
+++ b/src/features/review/steps/ReviewSteps.stories.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import { css } from '@emotion/react';
 
-import { type Softskills } from '~/components/graphic/softskills/type';
-
 import Cowork from './Cowork';
 import Intro from './Intro';
 import QuestionIntro from './QuestionIntro';
@@ -48,15 +46,21 @@ export function 질문_인트로() {
   );
 }
 
+const MOCK_SOFTSKILLS = [
+  { content: '개성이_뚜렷한', order: 0, choice_id: '456335196640616530' },
+  { content: '결단력_있는', order: 1, choice_id: '456335196640616531' },
+];
+
 export function 소프트_스킬() {
-  const [selectedSoftskills, setSelectedSoftskills] = useState<Softskills[]>([]);
+  const [selectedSoftskills, setSelectedSoftskills] = useState<string[]>([]);
 
   return (
     <main css={mainCss}>
       <Softskill
         nickname={MOCK_NICKNAME}
-        selectedSoftskills={selectedSoftskills}
-        setSelectedSoftskills={setSelectedSoftskills}
+        choices={MOCK_SOFTSKILLS}
+        selectedChoiceIds={selectedSoftskills}
+        setChoices={setSelectedSoftskills}
       />
     </main>
   );

--- a/src/features/review/steps/Softskill.tsx
+++ b/src/features/review/steps/Softskill.tsx
@@ -1,7 +1,6 @@
-import { type ChangeEventHandler, type Dispatch, type SetStateAction } from 'react';
+import { type ChangeEventHandler } from 'react';
 import { css } from '@emotion/react';
 
-import { softskillList } from '~/components/graphic/softskills/Softskill';
 import { type Softskills } from '~/components/graphic/softskills/type';
 import WarningIcon from '~/components/icons/WarningIcon';
 import Toast from '~/components/toast/Toast';
@@ -16,13 +15,14 @@ import { type StepProps } from './type';
 
 interface Props extends StepProps {
   nickname: Reviewer['nickname'];
-  selectedSoftskills: Softskills[];
-  setSelectedSoftskills: Dispatch<SetStateAction<Softskills[]>>;
+  choices: Choice[];
+  selectedChoiceIds: string[];
+  setChoices: (setStateAction: (prevState: string[]) => string[]) => void;
 }
 
 const MAX_LENGTH = 5;
 
-const Softskill = ({ prev, next, nickname, selectedSoftskills, setSelectedSoftskills }: Props) => {
+const Softskill = ({ prev, next, nickname, choices, selectedChoiceIds, setChoices }: Props) => {
   const { fireToast } = useToast();
 
   useDidMount(() => {
@@ -30,15 +30,15 @@ const Softskill = ({ prev, next, nickname, selectedSoftskills, setSelectedSoftsk
   });
 
   const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-    const clickedSoftskill = e.target.value as Softskills;
+    const clickedChoiceId = e.target.value;
 
     if (!e.target.checked) {
-      setSelectedSoftskills((prevSoftskills) => prevSoftskills.filter((softskill) => softskill !== clickedSoftskill));
+      setChoices((prevChoices) => prevChoices.filter((choice) => choice !== clickedChoiceId));
 
       return;
     }
 
-    if (selectedSoftskills.length >= MAX_LENGTH) {
+    if (selectedChoiceIds.length >= MAX_LENGTH) {
       e.target.checked = false;
 
       fireToast({
@@ -55,7 +55,7 @@ const Softskill = ({ prev, next, nickname, selectedSoftskills, setSelectedSoftsk
     }
 
     if (e.target.checked) {
-      setSelectedSoftskills((prevSoftskills) => [...prevSoftskills, clickedSoftskill]);
+      setChoices((prevSoftskills) => [...prevSoftskills, clickedChoiceId]);
     }
   };
 
@@ -66,19 +66,20 @@ const Softskill = ({ prev, next, nickname, selectedSoftskills, setSelectedSoftsk
         subTitle="키워드를 최대 5개까지 선택해주세요."
       />
       <section css={sectionCss}>
-        {softskillList.map((softskill) => (
+        {choices.map((softskill) => (
           <PillCheckbox
-            key={softskill}
-            graphicName={softskill}
-            name={softskill.replaceAll('_', ' ')}
+            key={softskill.choice_id}
+            graphicName={softskill.content as Softskills}
+            name={softskill.content.replaceAll('_', ' ')}
             onChange={onChange}
-            checked={selectedSoftskills.includes(softskill)}
+            value={softskill.choice_id}
+            checked={selectedChoiceIds.includes(softskill.choice_id)}
           />
         ))}
       </section>
       <BottomNavigation
         onBackClick={() => prev?.(2)}
-        isNextDisabled={!Boolean(selectedSoftskills.length)}
+        isNextDisabled={!Boolean(choices.length)}
         onNextClick={() => next?.()}
       />
     </>

--- a/src/features/review/steps/Softskill.tsx
+++ b/src/features/review/steps/Softskill.tsx
@@ -70,7 +70,7 @@ const Softskill = ({ prev, next, nickname, selectedSoftskills, setSelectedSoftsk
           <PillCheckbox
             key={softskill}
             graphicName={softskill}
-            name={softskill.replace('_', ' ')}
+            name={softskill.replaceAll('_', ' ')}
             onChange={onChange}
             checked={selectedSoftskills.includes(softskill)}
           />

--- a/src/features/review/steps/softskill/PillCheckbox.tsx
+++ b/src/features/review/steps/softskill/PillCheckbox.tsx
@@ -12,10 +12,10 @@ interface Props extends InputAttributes {
   name: string;
 }
 
-const PillCheckbox = ({ graphicName, name, ...rest }: Props) => {
+const PillCheckbox = ({ graphicName, name, value, ...rest }: Props) => {
   return (
     <label css={labelCss}>
-      <input type="checkbox" value={graphicName} {...rest} />
+      <input type="checkbox" value={value} {...rest} />
       <Pill color="default">
         <Softskill name={graphicName} />
         {name}

--- a/src/features/survey/addSurveyForm/AddSurveyForm.tsx
+++ b/src/features/survey/addSurveyForm/AddSurveyForm.tsx
@@ -85,7 +85,7 @@ const AddSurveyForm = ({ onClose, onAction }: Props) => {
         form_type: 'custom',
         title: questionInput,
         choices: choices,
-        max_selection_count: maxSelect,
+        max_selectable_count: maxSelect,
       };
 
       onAction(data);

--- a/src/features/survey/constants.ts
+++ b/src/features/survey/constants.ts
@@ -33,7 +33,7 @@ export const REQUEST_BASIC_QUESTION_LIST: QuestionRequest[] = [
     form_type: 'tendency',
     title: '동료들이 생각한 나의 이미지',
     choices: softSkillChoices,
-    max_selection_count: 5,
+    max_selectable_count: 5,
     order: 1,
   },
   {

--- a/src/features/survey/types.ts
+++ b/src/features/survey/types.ts
@@ -28,7 +28,7 @@ export interface ChoiceQuestionRequest {
   form_type: RequestQuestionFormType;
   title: string;
   choices: Choice[];
-  max_selection_count: number;
+  max_selectable_count: number;
   order: number;
 }
 
@@ -44,7 +44,7 @@ export interface ChoiceQuestionItem {
   form_type: 'custom';
   title: string;
   choices: Choice[];
-  max_selection_count: number;
+  max_selectable_count: number;
 }
 
 export interface ShortQuestionItem {

--- a/src/hooks/api/surveys/useGetSurveyById.ts
+++ b/src/hooks/api/surveys/useGetSurveyById.ts
@@ -22,7 +22,7 @@ interface ShortQuestion extends DefaultQuestion {
 
 interface ChoiceQuestion extends DefaultQuestion {
   type: 'choice';
-  max_selection_count: number;
+  max_selectable_count: number;
   choices: Choice[];
 }
 

--- a/src/hooks/api/surveys/usePostFeedbackBySurveyId.ts
+++ b/src/hooks/api/surveys/usePostFeedbackBySurveyId.ts
@@ -26,7 +26,7 @@ interface PostFeedbackRequest {
 
 const usePostFeedbackBySurveyId = (surveyId: string) => {
   const postFeedback = async (request: PostFeedbackRequest) => {
-    await post(`feedbacks?surveyId=${surveyId}`, request);
+    await post(`feedbacks?survey-id=${surveyId}`, request);
   };
 
   return postFeedback;

--- a/src/pages/review/LoadedSurvey.tsx
+++ b/src/pages/review/LoadedSurvey.tsx
@@ -49,24 +49,45 @@ const LoadedSurvey = ({ survey_id, target, question, question_count }: SurveyRes
       <Cowork key="cowork" nickname={target.nickname} isCoworked={isCoworked} setIsCoworked={setIsCoworked} />,
       <Position key="position" position={position} setPosition={setPosition} />,
       <QuestionIntro key="question-intro" nickname={target.nickname} />,
-      <Softskill
-        key="softskill"
-        nickname={target.nickname}
-        selectedSoftskills={selectedSoftskills}
-        setSelectedSoftskills={setSelectedSoftskills}
-      />,
-      // TODO: form_type 대응
-      ...question.map((eachQuestion, index) =>
-        eachQuestion.type === 'short' ? (
+      ...question.map((eachQuestion, index) => {
+        if (eachQuestion.form_type === 'tendency') {
+          return (
+            <Softskill
+              key="softskill"
+              nickname={target.nickname}
+              selectedSoftskills={selectedSoftskills}
+              setSelectedSoftskills={setSelectedSoftskills}
+            />
+          );
+        }
+
+        if (eachQuestion.form_type === 'strength') {
+          return (
+            <ShortQuestion
+              key="strength"
+              questionId={eachQuestion.question_id}
+              headerTitle={eachQuestion.title}
+              setReplies={setEachQuestionAnswer(eachQuestion.question_id)}
+              startMessages={[
+                {
+                  timing: 1000,
+                  text: '협업을 한 적이 없다면 일상에서 드러나는 성격이나 행동에 대한 장점을 적어주세요.',
+                },
+                { timing: 2000, text: '답변을 적어 저에게 메세지를 보내주시면, 익명으로 전달할게요!' },
+              ]}
+              afterUserMessages={[{ timing: 1000, text: '못한 말이 있다면 더 보낼 수 있어요.' }]}
+              isLastQuestion={index === question.length - 1}
+            />
+          );
+        }
+
+        return eachQuestion.type === 'short' ? (
           <ShortQuestion
             key={eachQuestion.question_id}
             questionId={eachQuestion.question_id}
             headerTitle={eachQuestion.title}
             setReplies={setEachQuestionAnswer(eachQuestion.question_id)}
-            startMessages={[
-              { timing: 1000, text: '협업을 한 적이 없다면 일상에서 드러나는 성격이나 행동에 대한 장점을 적어주세요.' },
-              { timing: 2000, text: '답변을 적어 저에게 메세지를 보내주시면, 익명으로 전달할게요!' },
-            ]}
+            startMessages={[{ timing: 1000, text: `${target.nickname} 님이 직접 입력한 질문이에요.` }]}
             isLastQuestion={index === question.length - 1}
           />
         ) : (
@@ -77,11 +98,11 @@ const LoadedSurvey = ({ survey_id, target, question, question_count }: SurveyRes
             selectedChoicesId={(questionAnswers[index] as ChoiceQuestionFeedback).choices}
             choices={eachQuestion.choices}
             setChoices={setEachQuestionAnswer(eachQuestion.question_id)}
-            max_selection_count={eachQuestion.max_selection_count}
+            max_selectable_count={eachQuestion.max_selectable_count}
             isLastQuestion={index === question.length - 1}
           />
-        ),
-      ),
+        );
+      }),
       <Last key="last" onSubmit={mutate} isLoading={isLoading} />,
     ],
   });


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

질문 폼 생성 api 이후 대응

## 🎉 변경 사항

- 기본 질문도 question에 함께 내려오는 것을 대응했어요
  - 소프트 스킬 상태 관리 로직을 일괄적으로 관리하도록 변경했어요

- `max_selectable_count`로 스펙이 바뀐 것을 대응했어요

- `ChoiceQuestion` step일 때 다음으로 넘어가는 상태를 추가헀어요

