### PR TITLE
프로덕션 환경 아닐 때 페이지 트랙 비활성화

### DIFF
--- a/src/hooks/event/usePageTrack.ts
+++ b/src/hooks/event/usePageTrack.ts
@@ -3,11 +3,14 @@ import { useRouter } from 'next/router';
 import mixpanel from 'mixpanel-browser';
 
 import { pageview } from '~/libs/gtag';
+import { isProd } from '~/utils/common';
 
 const usePageTrack = () => {
   const router = useRouter();
   useEffect(() => {
     const handleRouteChange = (url: URL) => {
+      if (!isProd(process.env.NODE_ENV)) return;
+
       pageview(url);
       mixpanel.track('Page view', { label: url, category: process.env.WEB_VERSION });
     };


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

- 개발 환경에서 gtag not a function 에러 

## 🎉 변경 사항

프로덕션 환경일 때만 수집하도록 변경
