### PR TITLE
인트로 스킵 기능 추가

### DIFF
--- a/src/features/review/steps/Intro.tsx
+++ b/src/features/review/steps/Intro.tsx
@@ -24,7 +24,7 @@ interface Props extends StepProps {
 
 const Intro = ({ nickname, next }: Props) => {
   const { currentStep, paragraphStep: onSkip } = useParagraphStep();
-  const { isCTAButtonVisible } = useCTAButtonVisible();
+  const { isCTAButtonVisible, skip: onCTAButtonVisibleSkip } = useCTAButtonVisible();
 
   useDidMount(() => {
     recordEvent({ action: '리뷰어 - 인트로' });
@@ -49,7 +49,7 @@ const Intro = ({ nickname, next }: Props) => {
               key="4"
               nickname={nickname}
               onSkip={() => {
-                // TODO : button 빠르게 나타내기
+                onCTAButtonVisibleSkip();
               }}
             />
           )}
@@ -210,7 +210,7 @@ const useCTAButtonVisible = () => {
     };
   }, [setTrue]);
 
-  return { isCTAButtonVisible };
+  return { isCTAButtonVisible, skip: setTrue };
 };
 
 interface SkipStaggerWrapperProps extends PropsWithChildren {

--- a/src/features/review/steps/Intro.tsx
+++ b/src/features/review/steps/Intro.tsx
@@ -44,15 +44,7 @@ const Intro = ({ nickname, next }: Props) => {
           {currentStep === 1 && <Paragraph1 key="1" nickname={nickname} onSkip={onSkip} />}
           {currentStep === 2 && <Paragraph2 key="2" onSkip={onSkip} />}
           {currentStep === 3 && <Paragraph3 key="3" onSkip={onSkip} />}
-          {currentStep === 4 && (
-            <Paragraph4
-              key="4"
-              nickname={nickname}
-              onSkip={() => {
-                onCTAButtonVisibleSkip();
-              }}
-            />
-          )}
+          {currentStep === 4 && <Paragraph4 key="4" nickname={nickname} onSkip={onCTAButtonVisibleSkip} />}
         </AnimatePresence>
       </article>
 
@@ -233,7 +225,6 @@ const SkipStaggerWrapper = ({
     if (!scope.current) return;
 
     await animate('div', { opacity: 1, scale: 1, y: [1, 0] }, { duration: 0.1 });
-
     setTimeout(onSkip, staggerDelay * 1000);
   };
 
@@ -245,6 +236,12 @@ const SkipStaggerWrapper = ({
     if (document) {
       document.body.addEventListener('click', onClick);
     }
+
+    return () => {
+      if (document) {
+        document.body.removeEventListener('click', onClick);
+      }
+    };
   });
 
   return (


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
close #334 

## 🎉 변경 사항
- document.body에 click event를 걸어 클릭하면 intro의 단계가 하나씩 스킵되는 기능을 추가하였습니다. 
- step을 빠르게 연속적으로 넘기면, step max값을 넘어가는 문제가 있어 수정하였습니다. 
### 🙏 여기는 꼭 봐주세요!
- 스킵 될 때 어느정도 애니매이션이 있어야 덜 어색한 것 같아. 작은 모션만 추가하였습니다. 
 > { opacity: 1, scale: 1, y: [1, 0] }, { duration: 0.1 }
- 기존에 사용하던 `StaggerWrapper` 컴포넌트로는 중간에 애니매이션을 바꾸는 동작을 구현하기 어려워, 새로운 컴포넌트를 만들어 사용하였습니다. 

## 🌄 스크린샷
![Jul-01-2023 16-33-52](https://github.com/depromeet/na-lab-client/assets/49177223/379fddf1-aa62-4460-9070-07bf056016e0)


## 📚 참고
- https://www.framer.com/motion/use-animate/
- https://www.framer.com/motion/animate-function/#options