### PR TITLE
Tooltip 컴포넌트 작성

### DIFF
--- a/src/components/tooltip/components/Tooltip.tsx
+++ b/src/components/tooltip/components/Tooltip.tsx
@@ -1,11 +1,17 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { TooltipProvider } from '../contexts/TooltipContext';
 import { type TooltipProps } from '../types';
 import { FloatingTooltip } from './Tooltip/FloatingTooltip';
 
 export function ControlledTooltip(props: TooltipProps) {
-  const { placement, offset, onClickOutside, interactive } = props;
+  const { placement, offset, onClickOutside, interactive, isShowing, onClose } = props;
+
+  useEffect(() => {
+    if (!isShowing && onClose) {
+      onClose();
+    }
+  }, [isShowing, onClose]);
 
   return (
     <TooltipProvider
@@ -22,16 +28,13 @@ export function ControlledTooltip(props: TooltipProps) {
 export function UncontrolledTooltip({ ...props }: TooltipProps) {
   const [isShowing, setIsShowing] = useState(true);
 
-  return (
-    <ControlledTooltip
-      {...props}
-      isShowing={isShowing}
-      onClose={() => setIsShowing(false)}
-      onChildrenClick={() => setIsShowing(!isShowing)}
-    />
-  );
+  return <ControlledTooltip {...props} isShowing={isShowing} onChildrenClick={() => setIsShowing(!isShowing)} />;
 }
 
+/**
+ * @description 툴팁을 부착하려는 요소를 <Tooltip>으로 감싸주세요.
+ * isShowing을 넘겨주지 않으면 Uncontrolled 방식의 툴팁을 사용할 수 있습니다.
+ */
 export function Tooltip(props: TooltipProps) {
   if (props.isShowing !== undefined) {
     return <ControlledTooltip {...props} />;

--- a/src/components/tooltip/components/Tooltip.tsx
+++ b/src/components/tooltip/components/Tooltip.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+import { TooltipProvider } from '../contexts/TooltipContext';
+import { type TooltipProps } from '../types';
+import { FloatingTooltip } from './Tooltip/FloatingTooltip';
+
+export function ControlledTooltip(props: TooltipProps) {
+  const { placement, offset, onClickOutside, interactive } = props;
+
+  return (
+    <TooltipProvider
+      placement={placement}
+      offsetNumber={offset}
+      onClickOutside={onClickOutside}
+      interactive={interactive}
+    >
+      <FloatingTooltip {...props} />
+    </TooltipProvider>
+  );
+}
+
+export function UncontrolledTooltip({ ...props }: TooltipProps) {
+  const [isShowing, setIsShowing] = useState(true);
+
+  return (
+    <ControlledTooltip
+      {...props}
+      isShowing={isShowing}
+      onClose={() => setIsShowing(false)}
+      onChildrenClick={() => setIsShowing(!isShowing)}
+    />
+  );
+}
+
+export function Tooltip(props: TooltipProps) {
+  if (props.isShowing !== undefined) {
+    return <ControlledTooltip {...props} />;
+  } else {
+    return <UncontrolledTooltip {...props} />;
+  }
+}

--- a/src/components/tooltip/components/Tooltip/Anchor.tsx
+++ b/src/components/tooltip/components/Tooltip/Anchor.tsx
@@ -1,0 +1,14 @@
+import Svg from '~/components/svg/Svg';
+
+export const Anchor = () => {
+  return (
+    <Svg width={19} height={17}>
+      <g transform="scale(1, -1) translate(0, -17)">
+        <path
+          d="M8.625 16.4186C9.00557 17.1064 9.99443 17.1064 10.375 16.4186L18.6381 1.48413C19.0069 0.817627 18.5249 0 17.7631 0H1.23686C0.475145 0 -0.00690329 0.817629 0.361868 1.48413L8.625 16.4186Z"
+          fill="#1D2942"
+        />
+      </g>
+    </Svg>
+  );
+};

--- a/src/components/tooltip/components/Tooltip/FloatingTooltip.tsx
+++ b/src/components/tooltip/components/Tooltip/FloatingTooltip.tsx
@@ -1,0 +1,162 @@
+import { cloneElement, useEffect, useLayoutEffect, useState } from 'react';
+import { css, type Theme } from '@emotion/react';
+import { AnimatePresence } from 'framer-motion';
+import { createPortal } from 'react-dom';
+
+import useIsMounted from '~/hooks/lifeCycle/useIsMounted';
+
+import TOOLTIP_STYLE from '../../constants/tooltipStyle';
+import { useTooltip } from '../../contexts/TooltipContext';
+import { useAnchorPosition } from '../../hooks/useAnchorPosition';
+import { type TooltipProps } from '../../types';
+import { mergeRefs } from '../../utils/mergeRefs';
+import { TooltipBase } from './TooltipBase';
+
+export function FloatingTooltip({ isShowing, children, ...props }: Omit<TooltipProps, 'interactive'>) {
+  const { targetRef } = useTooltip();
+  const childRef = children.ref;
+  const isMounted = useIsMounted();
+
+  const child = cloneElement(children, {
+    onClick: props.onChildrenClick,
+    ref: childRef ? mergeRefs(targetRef, childRef) : targetRef,
+  });
+
+  return (
+    <div style={{ width: '100%' }}>
+      {child}
+      {isMounted
+        ? createPortal(
+            <AnimatePresence>{isShowing && <FloatingTooltipContent key="tooltip" {...props} />}</AnimatePresence>,
+            document.body,
+          )
+        : null}
+    </div>
+  );
+}
+
+const FloatingTooltipContent = ({
+  message,
+  className,
+  placement = 'top',
+  contentPositionByRatio,
+}: Omit<TooltipProps, 'isShowing' | 'children' | 'interactive'>) => {
+  const { tooltipBaseRef, targetRef, floatingRef, offset } = useTooltip();
+
+  const [tooltipWidth, setTooltipWidth] = useState(0);
+  const [tooltipHeight, setTooltipHeight] = useState(0);
+  const [initialBoundingClientRect, setInitialBoundingClientRect] = useState<DOMRect | null>(null);
+
+  const isMounted = useIsMounted();
+
+  useLayoutEffect(() => {
+    if (targetRef && targetRef.current) {
+      setInitialBoundingClientRect(targetRef.current?.getBoundingClientRect());
+    }
+  }, [targetRef, targetRef?.current]);
+
+  useEffect(() => {
+    if (tooltipBaseRef?.current) {
+      setTooltipWidth(tooltipBaseRef.current.clientWidth);
+    }
+  }, [isMounted, tooltipBaseRef, tooltipBaseRef?.current?.clientWidth]);
+
+  useEffect(() => {
+    if (tooltipBaseRef?.current) {
+      setTooltipHeight(tooltipBaseRef.current.clientHeight);
+    }
+  }, [isMounted, initialBoundingClientRect, tooltipBaseRef, tooltipBaseRef?.current?.clientHeight]);
+
+  const { anchorWidth, anchorHeight } = TOOLTIP_STYLE;
+
+  const anchorMarginLeft = useAnchorPosition({
+    anchorPositionByRatio: contentPositionByRatio,
+    anchorWidth,
+    tooltipWidth,
+  });
+
+  return (
+    <>
+      {anchorMarginLeft &&
+        targetRef &&
+        targetRef.current &&
+        targetRef.current?.getBoundingClientRect() &&
+        initialBoundingClientRect && (
+          <div css={wrapperCss(document.documentElement.scrollHeight)}>
+            <TooltipBase
+              ref={floatingRef}
+              className={className}
+              message={message}
+              placement={placement}
+              anchorMarginLeft={anchorMarginLeft}
+              overrideCss={(theme) =>
+                tooltipBaseCss({
+                  theme,
+                  placement,
+                  initialLeft: initialBoundingClientRect.left ?? 0,
+                  initialWidth: initialBoundingClientRect.width ?? 0,
+                  offsetTop: targetRef.current?.offsetTop ?? 0,
+                  clientHeight: targetRef.current?.clientHeight ?? 0,
+                  anchorWidth,
+                  anchorHeight,
+                  anchorMarginLeft,
+                  tooltipHeight,
+                  offset,
+                })
+              }
+            />
+          </div>
+        )}
+    </>
+  );
+};
+
+const wrapperCss = (scrollHeight: number) => css`
+  pointer-events: none;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  overflow-x: hidden;
+  overflow-y: visible;
+
+  width: 100dvw;
+  height: ${scrollHeight}px;
+`;
+
+interface TooltipBaseCssProps {
+  theme: Theme;
+  placement: 'top' | 'bottom';
+  initialLeft: number;
+  initialWidth: number;
+  offsetTop: number;
+  clientHeight: number;
+  anchorWidth: number;
+  anchorHeight: number;
+  anchorMarginLeft: number;
+  tooltipHeight: number;
+  offset: number;
+}
+
+const tooltipBaseCss = ({
+  theme,
+  placement,
+  initialLeft,
+  initialWidth,
+  offsetTop,
+  clientHeight,
+  anchorWidth,
+  anchorHeight,
+  anchorMarginLeft,
+  tooltipHeight,
+  offset,
+}: TooltipBaseCssProps) => css`
+  pointer-events: 'auto';
+
+  position: absolute;
+  z-index: ${theme.zIndex.toast};
+  top: ${offsetTop +
+  (placement === 'top' ? -tooltipHeight - anchorHeight - offset : clientHeight + anchorHeight + offset)}px;
+  left: ${(initialLeft ?? 0) + (initialWidth ?? 0) / 2 - anchorWidth / 2 - anchorMarginLeft}px;
+`;

--- a/src/components/tooltip/components/Tooltip/FloatingTooltip.tsx
+++ b/src/components/tooltip/components/Tooltip/FloatingTooltip.tsx
@@ -12,13 +12,26 @@ import { type TooltipProps } from '../../types';
 import { mergeRefs } from '../../utils/mergeRefs';
 import { TooltipBase } from './TooltipBase';
 
-export function FloatingTooltip({ isShowing, children, ...props }: Omit<TooltipProps, 'interactive'>) {
+export function FloatingTooltip({ isShowing, children, onChildrenClick, ...props }: Omit<TooltipProps, 'interactive'>) {
   const { targetRef } = useTooltip();
   const childRef = children.ref;
   const isMounted = useIsMounted();
 
+  useEffect(() => {
+    if (targetRef) {
+      const currentTargetRef = targetRef.current;
+
+      if (currentTargetRef && onChildrenClick) {
+        currentTargetRef.addEventListener('click', onChildrenClick);
+
+        return () => {
+          currentTargetRef.removeEventListener('click', onChildrenClick);
+        };
+      }
+    }
+  }, [targetRef, onChildrenClick]);
+
   const child = cloneElement(children, {
-    onClick: props.onChildrenClick,
     ref: childRef ? mergeRefs(targetRef, childRef) : targetRef,
   });
 

--- a/src/components/tooltip/components/Tooltip/TooltipBase.tsx
+++ b/src/components/tooltip/components/Tooltip/TooltipBase.tsx
@@ -1,0 +1,126 @@
+import { forwardRef, type Ref, useRef } from 'react';
+import { css, type Theme } from '@emotion/react';
+import { m, type Variants } from 'framer-motion';
+
+import { BODY_2_REGULAR } from '~/styles/typo';
+
+import TOOLTIP_STYLE from '../../constants/tooltipStyle';
+import { useTooltip } from '../../contexts/TooltipContext';
+import { type TooltipBaseProps } from '../../types';
+import { mergeRefs } from '../../utils/mergeRefs';
+import { Anchor } from './Anchor';
+
+export const TooltipBase = forwardRef(function Tooltip(
+  { placement, className, anchorMarginLeft = 0, message, overrideCss }: TooltipBaseProps,
+  ref: Ref<HTMLDivElement>,
+) {
+  const { tooltipBaseRef } = useTooltip();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const { anchorWidth, anchorHeight, borderRadius, paddingX, paddingY } = TOOLTIP_STYLE;
+
+  return (
+    <div className={className} ref={mergeRefs(tooltipBaseRef, ref)} css={[htmlCss, overrideCss]}>
+      <m.div
+        css={transformOriginCss(placement, anchorWidth, anchorMarginLeft)}
+        variants={tooltipVariants}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        transition={{ type: 'spring' }}
+      >
+        <div ref={contentRef} css={(theme) => backgroundCss(theme, anchorHeight, paddingX, paddingY, borderRadius)}>
+          <div
+            css={anchorCss(
+              placement,
+              contentRef.current?.clientHeight ?? 0,
+              anchorWidth,
+              anchorHeight,
+              anchorMarginLeft,
+            )}
+          >
+            <Anchor />
+          </div>
+          <div css={(theme) => messageContainerCss(theme, anchorWidth, paddingX)}>
+            <p css={(theme) => messageCss(theme)}>{message}</p>
+          </div>
+        </div>
+      </m.div>
+    </div>
+  );
+});
+
+const htmlCss = css`
+  display: flex;
+`;
+
+const anchorCss = (
+  placement: 'top' | 'bottom',
+  clientHeight: number,
+  anchorWidth: number,
+  anchorHeight: number,
+  anchorMarginLeft: number,
+) => css`
+  position: absolute;
+  top: ${placement === 'top' ? clientHeight - 2.5 : -anchorHeight}px;
+  left: ${anchorMarginLeft}px;
+  transform: ${placement === 'top' ? 'scaleY(-1)' : 'none'};
+
+  display: flex;
+
+  width: ${anchorWidth}px;
+  height: ${anchorHeight + 2}px;
+`;
+
+const backgroundCss = (
+  theme: Theme,
+  anchorHeight: number,
+  paddingX: number,
+  paddingY: number,
+  borderRadius: number,
+) => css`
+  position: relative;
+
+  width: fit-content;
+  height: calc(100% - ${anchorHeight});
+  padding: ${paddingY / 2}px ${paddingX / 2}px;
+
+  background-color: ${theme.colors.secondary_200};
+  border-radius: ${borderRadius}px;
+`;
+
+const messageContainerCss = (theme: Theme, anchorWidth: number, paddingX: number) => css`
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  min-width: ${anchorWidth + paddingX / 2};
+
+  color: ${theme.colors.white};
+  text-align: center;
+`;
+
+const messageCss = (theme: Theme) => css`
+  ${BODY_2_REGULAR}
+
+  color: ${theme.colors.white}
+`;
+
+const transformOriginCss = (placement: 'top' | 'bottom', anchorWidth: number, anchorMarginLeft: number) => css`
+  transform-origin: ${anchorMarginLeft + anchorWidth / 2}px ${placement === 'bottom' ? 'top' : 'bottom'};
+`;
+
+const tooltipVariants: Variants = {
+  initial: {
+    opacity: 0,
+    scale: 0,
+  },
+  animate: {
+    opacity: 1,
+    scale: 1,
+    transition: { delay: 0.5 },
+  },
+  exit: {
+    opacity: 0,
+    scale: 0,
+  },
+};

--- a/src/components/tooltip/components/Tooltip/TooltipBase.tsx
+++ b/src/components/tooltip/components/Tooltip/TooltipBase.tsx
@@ -26,7 +26,6 @@ export const TooltipBase = forwardRef(function Tooltip(
         initial="initial"
         animate="animate"
         exit="exit"
-        transition={{ type: 'spring' }}
       >
         <div ref={contentRef} css={(theme) => backgroundCss(theme, anchorHeight, paddingX, paddingY, borderRadius)}>
           <div
@@ -116,8 +115,8 @@ const tooltipVariants: Variants = {
   },
   animate: {
     opacity: 1,
-    scale: 1,
-    transition: { delay: 0.5 },
+    scale: [0, 1.2, 1],
+    transition: { delay: 0.5, duration: 0.4, type: 'spring' },
   },
   exit: {
     opacity: 0,

--- a/src/components/tooltip/constants/tooltipStyle.ts
+++ b/src/components/tooltip/constants/tooltipStyle.ts
@@ -1,0 +1,9 @@
+const TOOLTIP_STYLE = {
+  borderRadius: 6,
+  paddingY: 20,
+  paddingX: 28,
+  anchorHeight: 12,
+  anchorWidth: 16,
+};
+
+export default TOOLTIP_STYLE;

--- a/src/components/tooltip/contexts/TooltipContext.tsx
+++ b/src/components/tooltip/contexts/TooltipContext.tsx
@@ -1,0 +1,54 @@
+import { createContext, type ReactNode, type RefObject, useContext, useRef } from 'react';
+
+import { useOnClickOutside } from '../hooks/useOnClickOutside';
+
+interface TooltipProviderProps {
+  children: ReactNode;
+  placement?: 'top' | 'bottom';
+  offsetNumber?: number;
+  interactive?: boolean;
+  onClickOutside?: () => void;
+}
+
+interface State {
+  tooltipBaseRef: RefObject<HTMLDivElement> | null;
+  targetRef: RefObject<HTMLDivElement> | null;
+  floatingRef: RefObject<HTMLDivElement> | null;
+  offset: number;
+}
+
+export const TooltipContext = createContext<State | null>(null);
+
+export function TooltipProvider({ children, offsetNumber = 0, onClickOutside, interactive }: TooltipProviderProps) {
+  const tooltipBaseRef = useRef<HTMLDivElement>(null);
+  const targetRef = useRef<HTMLDivElement>(null);
+  const floatingRef = useRef<HTMLDivElement>(null);
+
+  useOnClickOutside({ ref: tooltipBaseRef, onClickOutside, interactive });
+
+  return (
+    <TooltipContext.Provider
+      value={{
+        targetRef,
+        tooltipBaseRef,
+        floatingRef,
+        offset: offsetNumber,
+      }}
+    >
+      {children}
+    </TooltipContext.Provider>
+  );
+}
+
+export function useTooltip() {
+  const tooltip = useContext(TooltipContext);
+
+  return tooltip ?? DEFAULT_VALUE;
+}
+
+const DEFAULT_VALUE = {
+  tooltipBaseRef: null,
+  targetRef: null,
+  floatingRef: null,
+  offset: null,
+};

--- a/src/components/tooltip/hooks/useAnchorPosition.ts
+++ b/src/components/tooltip/hooks/useAnchorPosition.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+
+import useIsMounted from '~/hooks/lifeCycle/useIsMounted';
+
+import TOOLTIP_STYLE from '../constants/tooltipStyle';
+
+interface UseTailPositionProps {
+  anchorPositionByRatio?: number;
+  defaultPosition?: number;
+  anchorWidth: number;
+  tooltipWidth: number;
+}
+
+export function useAnchorPosition({
+  defaultPosition,
+  anchorPositionByRatio,
+  anchorWidth,
+  tooltipWidth,
+}: UseTailPositionProps) {
+  const isMounted = useIsMounted();
+
+  const getElementDistanceFromLeftByRatio = useCallback(
+    (ratio = 0) => {
+      return ratio * (tooltipWidth - TOOLTIP_STYLE.paddingX - anchorWidth) + TOOLTIP_STYLE.paddingX / 2;
+    },
+    [anchorWidth, tooltipWidth],
+  );
+
+  if (!isMounted) {
+    return defaultPosition;
+  }
+
+  if (anchorPositionByRatio != null) {
+    return getElementDistanceFromLeftByRatio(anchorPositionByRatio);
+  }
+
+  return defaultPosition ?? getElementDistanceFromLeftByRatio(0.5);
+}

--- a/src/components/tooltip/hooks/useOnClickOutside.ts
+++ b/src/components/tooltip/hooks/useOnClickOutside.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect } from 'react';
+
+export const useOnClickOutside = ({
+  ref,
+  onClickOutside,
+  interactive,
+}: {
+  ref: React.RefObject<HTMLDivElement>;
+  onClickOutside?: () => void;
+  interactive?: boolean;
+}) => {
+  const handleClick = useCallback(
+    (event: MouseEvent) => {
+      if (!onClickOutside) {
+        return;
+      }
+
+      const isClickTooltipOutside = ref.current && !ref.current.contains(event.target as Node);
+
+      if (!interactive || isClickTooltipOutside) {
+        onClickOutside();
+      }
+    },
+    [ref, onClickOutside, interactive],
+  );
+
+  useEffect(() => {
+    document.addEventListener('pointerdown', handleClick);
+
+    return () => {
+      document.removeEventListener('pointerdown', handleClick);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};

--- a/src/components/tooltip/index.ts
+++ b/src/components/tooltip/index.ts
@@ -1,0 +1,1 @@
+export { Tooltip } from './components/Tooltip';

--- a/src/components/tooltip/types.ts
+++ b/src/components/tooltip/types.ts
@@ -1,0 +1,36 @@
+import { type HTMLAttributes, type ReactElement, type RefCallback, type RefObject } from 'react';
+import { type Interpolation, type Theme } from '@emotion/react';
+
+export interface AnchorProps {
+  /**
+   * @description
+   * normal Tooltip의 경우, 꼬리는 children의 가운데로 고정됩니다. contentPositionByRatio만큼 content가 움직입니다.
+   */
+  contentPositionByRatio?: number;
+}
+
+type ReactElementWithRef = ReactElement & {
+  ref?: RefObject<any> | RefCallback<any>;
+};
+
+export interface TooltipProps extends Pick<AnchorProps, 'contentPositionByRatio'> {
+  isShowing?: boolean;
+  className?: string;
+  children: ReactElementWithRef;
+  message: string | ReactElement;
+  placement?: 'top' | 'bottom';
+  offset?: number;
+  interactive?: boolean;
+  onClose?: () => void;
+  onClickOutside?: () => void;
+  onChildrenClick?: () => void;
+}
+
+export interface TooltipBaseProps extends HTMLAttributes<HTMLDivElement> {
+  message?: string | ReactElement;
+  className?: string;
+  background?: ReactElement;
+  placement: 'top' | 'bottom';
+  anchorMarginLeft?: number;
+  overrideCss?: Interpolation<Theme>;
+}

--- a/src/components/tooltip/types.ts
+++ b/src/components/tooltip/types.ts
@@ -4,7 +4,7 @@ import { type Interpolation, type Theme } from '@emotion/react';
 export interface AnchorProps {
   /**
    * @description
-   * normal Tooltip의 경우, 꼬리는 children의 가운데로 고정됩니다. contentPositionByRatio만큼 content가 움직입니다.
+   * 꼬리의 위치를 설정합니다. contentPositionByRatio만큼 content가 움직입니다. undefined일 경우 children의 가운데에 꼬리가 위치합니다.
    */
   contentPositionByRatio?: number;
 }
@@ -14,15 +14,49 @@ type ReactElementWithRef = ReactElement & {
 };
 
 export interface TooltipProps extends Pick<AnchorProps, 'contentPositionByRatio'> {
+  /**
+   * @description
+   * 툴팁이 켜지고 꺼지는 상태
+   */
   isShowing?: boolean;
   className?: string;
   children: ReactElementWithRef;
+  /**
+   * @description
+   * 문구를 string 혹은 jsx로 넣어주세요
+   */
   message: string | ReactElement;
+  /**
+   * @description
+   * 툴팁이 children의 위, 아래 중 어디로 위치할지 결정합니다. 기본값은 top입니다.
+   * @default "top"
+   */
   placement?: 'top' | 'bottom';
+  /**
+   * @description
+   * 툴팁이 children에서 얼마나 떨어져있을지 결정합니다. 기본값은 7px입니다.
+   * @default 7
+   */
   offset?: number;
+  /**
+   * @description
+   * 툴팁 내부를 클릭했을때, 꺼지지 않고 툴팁 내부의 요소와 상호작용 할 수 있게 해줍니다.
+   */
   interactive?: boolean;
+  /**
+   * @description
+   * 툴팁이 꺼질 때 호출될 함수
+   */
   onClose?: () => void;
+  /**
+   * @description
+   * 툴팁 바깥 영역을 클릭했을 때 호출될 함수
+   */
   onClickOutside?: () => void;
+  /**
+   * @description
+   * children을 클릭했을 때 호출될 함수
+   */
   onChildrenClick?: () => void;
 }
 

--- a/src/components/tooltip/utils/mergeRefs.ts
+++ b/src/components/tooltip/utils/mergeRefs.ts
@@ -1,0 +1,11 @@
+export function mergeRefs<T = any>(...refs: Array<React.MutableRefObject<T> | React.LegacyRef<T>>): React.Ref<T> {
+  return (value) => {
+    refs.forEach((ref) => {
+      if (typeof ref === 'function') {
+        ref(value);
+      } else if (ref != null) {
+        (ref as React.MutableRefObject<T | null>).current = value;
+      }
+    });
+  };
+}

--- a/src/hooks/lifeCycle/useIsMounted.test.ts
+++ b/src/hooks/lifeCycle/useIsMounted.test.ts
@@ -1,0 +1,15 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { describe, expect, test } from 'vitest';
+
+import useIsMounted from './useIsMounted';
+
+describe('hooks/lifeCycle/useIsMounted', () => {
+  test('정의되어 있는가', () => {
+    expect(useIsMounted).toBeDefined();
+  });
+
+  test('mount되면 true를 반환한다.', () => {
+    const { result } = renderHook(() => useIsMounted());
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/hooks/lifeCycle/useIsMounted.ts
+++ b/src/hooks/lifeCycle/useIsMounted.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+
+const useIsMounted = () => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return mounted;
+};
+
+export default useIsMounted;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

#360 

## 🎉 변경 사항

Tooltip 컴포넌트를 만들었어요.

### 🙏 여기는 꼭 봐주세요!

### 사용 방법

툴팁을 부착하고싶은 요소를 `<Tooltip>`으로 감싸주세요.

툴팁이 켜지고, 꺼지는 것을 나타내는 상태인 `isShowing`을 전달해주세요.
툴팁 내에 넣을 메시지는 `message`로 전달해주세요.
툴팁을 위쪽에 놓을건지, 아래쪽에 놓을건지 > `placement`
툴팁이 children에서 얼마나 떨어져있을건지 > `offset`

툴팁을 부착한 children을 클릭했을 때 함수를 실행하고싶다 > `onChildrenClick`
툴팁이 꺼질때 함수를 실행하고싶다 > `onClose`
툴팁 외부 영역을 클릭했을 때 함수를 실행하고싶다 > `onClickOutside`

툴팁을 좌우로 움직이려면 `contentPositionByRatio`에 0~1사이의 비율을 전달해주세요. 0을 전달하면 꼬리가 툴팁의 왼쪽 끝으로, 1을 전달하면 오른쪽 끝으로 이동합니다.
`contentPositionByRatio`을 전달하지 않으면 꼬리는 툴팁의 가운데에 위치합니다.

첫 렌더링과 동시에 툴팁이 떠오르면 약간 버벅여서 0.5초 딜레이를 주었습니다.

```js
        <Tooltip
            onClickOutside={() => setIsShowing(false)}
            isShowing={isShowing}
            contentPositionByRatio={1}
            placement="top"
            message="이곳에 나의 직무를 입력해 주세요."
          >
            <h1 css={titleCss}>나의 커리어 DNA 연구소</h1>
          </Tooltip>
```

## 🌄 스크린샷
![Monosnap screencast 2023-07-07 01-49-49](https://github.com/depromeet/na-lab-client/assets/82137004/cd229bb8-e4d2-425d-89be-67c2b6ff843e)



## 📚 참고
