### PR TITLE
다른 사람 DNA 페이지에 질문 폼 만든 사람이 방문했을 때 대응

### DIFF
--- a/src/features/dna/BookmarkSection.tsx
+++ b/src/features/dna/BookmarkSection.tsx
@@ -1,5 +1,5 @@
 import { type FC } from 'react';
-import { css } from '@emotion/react';
+import { css, type Theme } from '@emotion/react';
 
 import { type DnaOwnerStatus } from '~/pages/dna/type';
 import { HEAD_2_BOLD } from '~/styles/typo';
@@ -48,7 +48,7 @@ const BookmarkSection: FC<Props> = ({ bookmarkedFeedbacks, dnaOwnerStatus }) => 
 
 export default BookmarkSection;
 
-const crewFeedbackContainer = css`
+const crewFeedbackContainer = (theme: Theme) => css`
   transform: translateX(-23px);
 
   display: flex;
@@ -57,13 +57,13 @@ const crewFeedbackContainer = css`
   width: calc(100% + 23px + 23px);
   padding: 20px 23px 84px;
 
-  background: var(--gray-50-background-secondary, #f4f5f9);
+  background-color: ${theme.colors.gray_50};
 `;
 
-const subTitleCss = css`
+const subTitleCss = (theme: Theme) => css`
   ${HEAD_2_BOLD};
 
-  color: var(--gray-500-text-secondary, #394258);
+  color: ${theme.colors.gray_500};
 `;
 
 const NothingBookmarked = () => {

--- a/src/features/dna/DnaCta.tsx
+++ b/src/features/dna/DnaCta.tsx
@@ -20,9 +20,7 @@ interface Props {
 const DnaCta: FC<Props> = ({ surveyId, dnaOwnerStatus, userInfo }) => {
   const router = useInternalRouter();
   const { fireToast } = useToast();
-  const { data: visitedUserSurveyId, isInitialLoading } = useGetSurveyIdByUserStatus();
-
-  console.log(visitedUserSurveyId, isInitialLoading);
+  const { data: visitedUserSurveyId } = useGetSurveyIdByUserStatus();
 
   const onClickCopyCTA = () => {
     recordEvent({ action: 'DNA 페이지 - 커리어 명함 링크 복사 클릭' });

--- a/src/features/dna/DnaCta.tsx
+++ b/src/features/dna/DnaCta.tsx
@@ -4,6 +4,7 @@ import { css, type Theme } from '@emotion/react';
 import CTAButton from '~/components/button/CTAButton';
 import useToast from '~/components/toast/useToast';
 import { Tooltip } from '~/components/tooltip';
+import useGetSurveyIdByUserStatus from '~/hooks/api/surveys/useGetSurveyIdByUserStatus';
 import type useGetUserInfoBySurveyId from '~/hooks/api/user/useGetUserInfoBySurveyId';
 import useInternalRouter from '~/hooks/router/useInternalRouter';
 import { type DnaOwnerStatus } from '~/pages/dna/type';
@@ -19,6 +20,9 @@ interface Props {
 const DnaCta: FC<Props> = ({ surveyId, dnaOwnerStatus, userInfo }) => {
   const router = useInternalRouter();
   const { fireToast } = useToast();
+  const { data: visitedUserSurveyId, isInitialLoading } = useGetSurveyIdByUserStatus();
+
+  console.log(visitedUserSurveyId, isInitialLoading);
 
   const onClickCopyCTA = () => {
     recordEvent({ action: 'DNA 페이지 - 커리어 명함 링크 복사 클릭' });
@@ -29,23 +33,39 @@ const DnaCta: FC<Props> = ({ surveyId, dnaOwnerStatus, userInfo }) => {
     fireToast({ content: `${userInfo?.nickname}님의 커리어 명함 링크가 복사되었어요`, higherThanCTA: true });
   };
 
+  const onClickMyResultCTA = () => {
+    recordEvent({ action: 'DNA 페이지 - 내 결과 보러 가기 클릭' });
+
+    router.push('/result');
+  };
+
   const onClickCareerCTA = () => {
     recordEvent({ action: 'DNA 페이지 - 나도 커리어 질문 폼 생성하기 클릭' });
 
     router.push('/survey');
   };
 
-  return (
-    <div css={wrapperCss}>
-      {dnaOwnerStatus === 'current_user' ? (
+  if (dnaOwnerStatus === 'current_user')
+    return (
+      <div css={wrapperCss}>
         <CTAButton onClick={onClickCopyCTA}>공유하기</CTAButton>
-      ) : (
-        <Tooltip message="단 3분이면 나의 질문 폼 링크를 만들 수 있어요!" placement="top" offset={7}>
-          <CTAButton color="blue" onClick={onClickCareerCTA}>
-            나도 커리어 질문 폼 공유하기
-          </CTAButton>
-        </Tooltip>
-      )}
+      </div>
+    );
+
+  if (Boolean(visitedUserSurveyId))
+    return (
+      <div css={fullGrayBackgroundWrapperCss}>
+        <CTAButton onClick={onClickMyResultCTA}>내 결과 보러 가기</CTAButton>
+      </div>
+    );
+
+  return (
+    <div css={fullGrayBackgroundWrapperCss}>
+      <Tooltip message="단 3분이면 나의 질문 폼 링크를 만들 수 있어요!" placement="top" offset={7}>
+        <CTAButton color="blue" onClick={onClickCareerCTA}>
+          나도 커리어 질문 폼 공유하기
+        </CTAButton>
+      </Tooltip>
     </div>
   );
 };
@@ -62,4 +82,12 @@ const wrapperCss = (theme: Theme) => css`
 
   width: 100%;
   max-width: ${theme.size.maxWidth};
+`;
+
+const fullGrayBackgroundWrapperCss = (theme: Theme) => css`
+  transform: translateX(-23px);
+  width: calc(100% + 23px + 23px);
+  padding: 0 23px;
+  padding-bottom: 12px;
+  background-color: ${theme.colors.gray_50};
 `;

--- a/src/features/dna/DnaCta.tsx
+++ b/src/features/dna/DnaCta.tsx
@@ -53,7 +53,7 @@ const DnaCta: FC<Props> = ({ surveyId, dnaOwnerStatus, userInfo }) => {
   if (Boolean(visitedUserSurveyId))
     return (
       <div css={fullGrayBackgroundWrapperCss}>
-        <CTAButton onClick={onClickMyResultCTA}>내 결과 보러 가기</CTAButton>
+        <CTAButton onClick={onClickMyResultCTA}>내 피드백 결과 보러 가기</CTAButton>
       </div>
     );
 


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

- 이미 질문 폼이 있는 사람한테, 생성 CTA 버튼을 안보여주어야함

- close #398 

## 🎉 변경 사항

- 내 DNA가 아닌 이상, CTA 버튼이 플로팅하지 않아요

- 남의 DNA + 질문 폼이 있으면 '내 피드백 결과 보러 가기' 를 띄워요

- 이외의 환경에서는 기존의 '나도 커리어 질문 폼 공유하기'를 띄워요
