### PR TITLE
header 영역이 조금 짧은 ui 수정

### DIFF
--- a/src/features/review/QuestionHeader.tsx
+++ b/src/features/review/QuestionHeader.tsx
@@ -12,14 +12,16 @@ interface Props {
 const QuestionHeader = ({ title, subTitle }: Props) => {
   return (
     <m.header css={headerCss} variants={stagger(0.5)} initial="initial" animate="animate" exit="exit">
-      <m.h1 css={headingCss} variants={fadeInUpVariants}>
-        {title}
-      </m.h1>
-      {subTitle && (
-        <m.small css={smallCss} variants={defaultFadeInVariants}>
-          {subTitle}
-        </m.small>
-      )}
+      <div css={wrapperCss}>
+        <m.h1 css={headingCss} variants={fadeInUpVariants}>
+          {title}
+        </m.h1>
+        {subTitle && (
+          <m.small css={smallCss} variants={defaultFadeInVariants}>
+            {subTitle}
+          </m.small>
+        )}
+      </div>
     </m.header>
   );
 };
@@ -31,13 +33,17 @@ const headerCss = (theme: Theme) => css`
   z-index: ${theme.zIndex.belowFixed};
   top: 0;
 
-  /* 오른쪽 상단 1/6 같은 status와 겹치게 하지 않기 위함 */
-  width: calc(100% - 50px);
+  width: 100%;
   padding-top: 34px;
   padding-bottom: 14px;
 
   background-color: rgb(255 255 255 / 50%);
   backdrop-filter: blur(5px);
+`;
+
+const wrapperCss = css`
+  /* 오른쪽 상단 1/6 같은 status와 겹치게 하지 않기 위함 */
+  width: calc(100% - 50px);
 `;
 
 const headingCss = css`


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?

## 🎉 변경 사항

header가 조금 짧아서 블러가 부족한 ui를 수정합니다.

asis
<img width="132" alt="image" src="https://github.com/depromeet/na-lab-client/assets/82137004/b48ee682-5bc7-4224-a5d9-17107aea3eb8">

tobe
<img width="191" alt="image" src="https://github.com/depromeet/na-lab-client/assets/82137004/a7dbf54c-e8c7-435e-b9c9-c0cc21b36240">


### 🙏 여기는 꼭 봐주세요!

### 사용 방법

## 🌄 스크린샷

## 📚 참고
