### PR TITLE
이미지 다운로드 png로 타입 변경

### DIFF
--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -9,7 +9,9 @@ export const imageDownloadPC = (imgSrc: string, fileName: string) => {
 export const imageShare = async (imageUrl: string): Promise<boolean> => {
   if (navigator.share) {
     const blob = await (await fetch(imageUrl)).blob();
-    const file = new File([blob], `DNA.png`, { type: blob.type });
+    const file = new File([blob], `DNA.png`, {
+      type: 'image/png',
+    });
     if (navigator.canShare && navigator.canShare({ files: [file] })) {
       navigator.share({
         title: '나만의 커리어 명함',


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
이미지 다운시 share 기능에 갤러리로 저장이 없어요
## 🎉 변경 사항
- file에 타입 지정